### PR TITLE
Better messaging when provided `value` cannot be encoded as specified `type`

### DIFF
--- a/eth_account/_utils/structured_data/hashing.py
+++ b/eth_account/_utils/structured_data/hashing.py
@@ -246,20 +246,15 @@ def _encode_data(primary_type, types, data):
                     )
                 )
 
-            # Next see if the data fits the specified encoding type
+            # Next, see if the value is encodable as the specified type
             if is_encodable(field["type"], value):
-                # field["type"] is a valid type and this value corresponds to that type.
+                # field["type"] is a valid type and the provided value is encodable as that type
                 yield field["type"], value
             else:
                 raise TypeError(
-                    "Value of `{0}` ({2}) in the struct `{1}` is of the type `{3}`, but expected "
-                    "{4} value".format(
-                        field["name"],
-                        primary_type,
-                        value,
-                        type(value),
-                        field["type"],
-                    )
+                    f"Value of `{field['name']}` ({value}) in the struct `{primary_type}` is not "
+                    f"encodable as the specified type `{field['type']}`. If the base type is "
+                    "correct, make sure the value does not exceed the specified size for the type."
                 )
 
 

--- a/newsfragments/144.misc.rst
+++ b/newsfragments/144.misc.rst
@@ -1,0 +1,1 @@
+Improve messaging in ``TypeError`` when a provided ``value`` cannot be encoded as the specified abi ``type`` for structured data.

--- a/tests/core/test_accounts.py
+++ b/tests/core/test_accounts.py
@@ -180,7 +180,7 @@ def acct(request):
         raise Exception(f"account invocation {request.param} is not supported")
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def keyed_acct():
     return Account.from_key(PRIVATE_KEY_AS_BYTES)
 

--- a/tests/core/test_structured_data_signing.py
+++ b/tests/core/test_structured_data_signing.py
@@ -265,7 +265,7 @@ def test_invalid_structured_data_invalid_abi_type():
 
 
 def test_structured_data_invalid_identifier_filtered_by_abi_encodable_function():
-    # Given valid abi type, but the value is not of the specified type
+    # Given valid abi type, but the value is not encodable as the specified type
     # (Error is found by the ``is_encodable`` ABI function)
     invalid_structured_data_string = open(
         "tests/fixtures/invalid_message_valid_abi_type_invalid_value.json"
@@ -274,8 +274,9 @@ def test_structured_data_invalid_identifier_filtered_by_abi_encodable_function()
     with pytest.raises(TypeError) as e:
         hash_message(invalid_structured_data)
     assert (
-        str(e.value) == "Value of `balance` (how do you do?) in the struct `Person` is of the "
-        "type `<class 'str'>`, but expected uint256 value"
+        str(e.value) == "Value of `balance` (how do you do?) in the struct `Person` is not "
+                        "encodable as the specified type `uint256`. If the base type is correct, "
+                        "make sure the value does not exceed the specified size for the type."
     )
 
 


### PR DESCRIPTION
## What was wrong?

- Unclear messaging when the `value` provided for a specified `type` in structured data matches the base type but exceeds the specified size.
- Related message in issue #140

## How was it fixed?

- Clearer message based on the logic that is happening. In the logic surrounding this, we check if the provided `value` can be encoded as the provided `type` via `is_encodable()`. The messaging was changed to be a bit more clear that the `value` provided is not encodable as the specified `type`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fus.whales.org%2Fwp-content%2Fuploads%2Fsites%2F2%2F2018%2F06%2Fnarwhal-wdc-7.jpg&f=1&nofb=1)
