### PR TITLE
Add and update tests for encode_structured_data

### DIFF
--- a/newsfragments/68.misc.rst
+++ b/newsfragments/68.misc.rst
@@ -1,0 +1,1 @@
+Add tests for more complex tuple / struct types for encoding structured data and refactor / add back the EIP-712 tests for easier reference

--- a/tests/core/test_structured_data_signing.py
+++ b/tests/core/test_structured_data_signing.py
@@ -34,40 +34,81 @@ from eth_account.messages import (
 
 
 @pytest.fixture
-def structured_valid_data_json_string():
-    return open("tests/fixtures/valid_message.json", "r").read()
+def eip712_example_json_string():
+    return open("tests/fixtures/valid_eip712_example.json", "r").read()
 
 
 @pytest.fixture
-def types(structured_valid_data_json_string):
-    return json.loads(structured_valid_data_json_string)["types"]
+def eip712_example_types(eip712_example_json_string):
+    return json.loads(eip712_example_json_string)["types"]
 
 
 @pytest.fixture
-def domain_type(structured_valid_data_json_string):
-    return json.loads(structured_valid_data_json_string)["types"]["EIP712Domain"]
+def eip712_example_domain_type(eip712_example_json_string):
+    return json.loads(eip712_example_json_string)["types"]["EIP712Domain"]
 
 
 @pytest.fixture
-def message(structured_valid_data_json_string):
-    return json.loads(structured_valid_data_json_string)["message"]
+def eip712_example_message(eip712_example_json_string):
+    return json.loads(eip712_example_json_string)["message"]
 
 
 @pytest.fixture
-def domain(structured_valid_data_json_string):
-    return json.loads(structured_valid_data_json_string)["domain"]
+def eip712_example_domain(eip712_example_json_string):
+    return json.loads(eip712_example_json_string)["domain"]
 
 
 @pytest.fixture(params=("text", "dict", "primitive", "hexstr"))
-def message_encodings(request, structured_valid_data_json_string):
+def eip712_message_encodings(request, eip712_example_json_string):
     if request.param == "text":
-        return {"text": structured_valid_data_json_string}
+        return {"text": eip712_example_json_string}
     elif request.param == "primitive":
-        return {"primitive": structured_valid_data_json_string.encode()}
+        return {"primitive": eip712_example_json_string.encode()}
     elif request.param == "dict":
-        return {"primitive": json.loads(structured_valid_data_json_string)}
+        return {"primitive": json.loads(eip712_example_json_string)}
     elif request.param == "hexstr":
-        return {"hexstr": structured_valid_data_json_string.encode().hex()}
+        return {"hexstr": eip712_example_json_string.encode().hex()}
+    else:
+        raise Exception("Unreachable")
+
+
+# --- EIP 712 example with added "cc" array field to Mail struct --- #
+
+@pytest.fixture
+def eip712_example_with_array_json_string():
+    return open("tests/fixtures/valid_eip712_example_with_array.json", "r").read()
+
+
+@pytest.fixture
+def eip712_example_with_array_types(eip712_example_with_array_json_string):
+    return json.loads(eip712_example_with_array_json_string)["types"]
+
+
+@pytest.fixture
+def eip712_example_with_array_domain_type(eip712_example_with_array_json_string):
+    return json.loads(eip712_example_with_array_json_string)["types"]["EIP712Domain"]
+
+
+@pytest.fixture
+def eip712_example_with_array_message(eip712_example_with_array_json_string):
+    return json.loads(eip712_example_with_array_json_string)["message"]
+
+
+@pytest.fixture
+def eip712_example_with_array_domain(eip712_example_with_array_json_string):
+    return json.loads(eip712_example_with_array_json_string)["domain"]
+
+
+@pytest.fixture(params=("text", "dict", "primitive", "hexstr"))
+def eip712_with_array_message_encodings(request, eip712_example_with_array_json_string):
+    if request.param == "text":
+        return {"text": eip712_example_with_array_json_string}
+    elif request.param == "primitive":
+        return {"primitive": eip712_example_with_array_json_string.encode()}
+    elif request.param == "dict":
+        return {"primitive": json.loads(eip712_example_with_array_json_string)}
+    elif request.param == "hexstr":
+        return {"hexstr": eip712_example_with_array_json_string.encode().hex()}
     else:
         raise Exception("Unreachable")
 
@@ -79,8 +120,33 @@ def message_encodings(request, structured_valid_data_json_string):
         ('Person', ()),
     )
 )
-def test_get_dependencies(primary_type, types, expected):
-    assert get_dependencies(primary_type, types) == expected
+def test_get_dependencies_eip712(primary_type, expected, eip712_example_types):
+    assert get_dependencies(primary_type, eip712_example_types) == expected
+
+
+@pytest.mark.parametrize(
+    'primary_type, expected',
+    (
+        ('Mail', ('Person',)),
+        ('Person', ()),
+    )
+)
+def test_get_dependencies_eip712_with_array(
+    primary_type, expected, eip712_example_with_array_types
+):
+    assert get_dependencies(primary_type, eip712_example_with_array_types) == expected
+
+
+@pytest.mark.parametrize(
+    'struct_name, expected',
+    (
+        ("Mail", "Mail(Person from,Person to,string contents)"),
+        ("Person", "Person(string name,address wallet)"),
+        ("EIP712Domain", "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),  # noqa: E501
+    )
+)
+def test_encode_struct_eip712(struct_name, expected, eip712_example_types):
+    assert encode_struct(struct_name, eip712_example_types[struct_name]) == expected
 
 
 @pytest.mark.parametrize(
@@ -88,14 +154,22 @@ def test_get_dependencies(primary_type, types, expected):
     (
         ("Mail", "Mail(Person from,Person to,Person[] cc,string contents)"),
         ("Person", "Person(string name,address wallet)"),
-        ("EIP712Domain", (
-            "EIP712Domain(string name,string version,"
-            "uint256 chainId,address verifyingContract)"
-        )),
+        ("EIP712Domain", "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),  # noqa: E501
     )
 )
-def test_encode_struct(struct_name, types, expected):
-    assert encode_struct(struct_name, types[struct_name]) == expected
+def test_encode_struct_eip712_with_array(struct_name, expected, eip712_example_with_array_types):
+    assert encode_struct(struct_name, eip712_example_with_array_types[struct_name]) == expected
+
+
+@pytest.mark.parametrize(
+    'primary_type, expected',
+    (
+        ('Mail', 'Mail(Person from,Person to,string contents)Person(string name,address wallet)'),  # noqa: E501
+        ('Person', 'Person(string name,address wallet)'),
+    )
+)
+def test_encode_type_eip712(primary_type, expected, eip712_example_types):
+    assert encode_type(primary_type, eip712_example_types) == expected
 
 
 @pytest.mark.parametrize(
@@ -105,53 +179,143 @@ def test_encode_struct(struct_name, types, expected):
         ('Person', 'Person(string name,address wallet)'),
     )
 )
-def test_encode_type(primary_type, types, expected):
-    assert encode_type(primary_type, types) == expected
+def test_encode_type_eip712_with_array(primary_type, expected, eip712_example_with_array_types):
+    assert encode_type(primary_type, eip712_example_with_array_types) == expected
 
 
 @pytest.mark.parametrize(
-    'primary_type, expected_hex_value',
+    'primary_type, expected_hex',
     (
-        ('Mail', 'b19c5c7781083ed7325660d847f8c547b744917d67b38858b00bce7e62a4866b'),
+        ('Mail', 'a0cedeb2dc280ba39b857546d74f5549c3a1d7bdc2dd96bf881f76108e23dac2'),
         ('Person', 'b9d8c78acf9b987311de6c7b45bb6a9c8e1bf361fa7fd3467a2163f994c79500'),
     )
 )
-def test_hash_struct_type(primary_type, types, expected_hex_value):
-    assert hash_struct_type(primary_type, types).hex() == expected_hex_value
+def test_hash_struct_type_eip712(primary_type, expected_hex, eip712_example_types):
+    assert hash_struct_type(primary_type, eip712_example_types).hex() == expected_hex
 
 
-def test_encode_data(types, message):
-    primary_type = "Mail"
-    expected_hex_value = (
-        "b19c5c7781083ed7325660d847f8c547b744917d67b38858b00bce7e62a4866bfc71e5fa27ff56c350aa531bc1"
-        "29ebdf613b772b6604664f5d8dbe21b85eb0c8cd54f074a4af31b4411ff6a60c9719dbd559c221c8ac3492d9d8"
-        "72b041d703d1a88b5e35e8f6bccc3d72ef467ed581615888f8cf34df19d068d04225439be65ab5aadf3154a261"
-        "abdd9086fc627b61efca26ae5702701d05cd2305f7c52a2fc8"
+@pytest.mark.parametrize(
+    'primary_type, expected_hex',
+    (
+        ('Person', 'b9d8c78acf9b987311de6c7b45bb6a9c8e1bf361fa7fd3467a2163f994c79500'),
+        ('Mail', 'b19c5c7781083ed7325660d847f8c547b744917d67b38858b00bce7e62a4866b'),
     )
-    assert encode_data(primary_type, types, message).hex() == expected_hex_value
+)
+def test_hash_struct_type_eip712_with_array(
+    primary_type, expected_hex, eip712_example_with_array_types
+):
+    assert hash_struct_type(primary_type, eip712_example_with_array_types).hex() == expected_hex
 
 
-def test_hash_struct_main_message(structured_valid_data_json_string):
-    structured_data = json.loads(structured_valid_data_json_string)
-    expected_hex_value = "76649452daa3e4101beef5b01669fd0de45ece35188d529703c73526a2454521"
-    assert hash_message(structured_data).hex() == expected_hex_value
+def test_encode_data_eip712(eip712_example_types, eip712_example_message):
+    primary_type = "Mail"
+    expected_hex = (
+        "a0cedeb2dc280ba39b857546d74f5549c3a1d7bdc2dd96bf881f76108e23dac2fc71e5fa27ff56c350aa"
+        "531bc129ebdf613b772b6604664f5d8dbe21b85eb0c8cd54f074a4af31b4411ff6a60c9719dbd559c221"
+        "c8ac3492d9d872b041d703d1b5aadf3154a261abdd9086fc627b61efca26ae5702701d05cd2305f7c52a"
+        "2fc8"
+    )
+    assert encode_data(primary_type, eip712_example_types, eip712_example_message).hex() == expected_hex  # noqa: E501
 
 
-def test_hash_struct_domain(structured_valid_data_json_string):
-    structured_data = json.loads(structured_valid_data_json_string)
-    expected_hex_value = "f2cee375fa42b42143804025fc449deafd50cc031ca257e0b194a650a912090f"
-    assert hash_domain(structured_data).hex() == expected_hex_value
+def test_encode_data_eip712_with_array(
+    eip712_example_with_array_types, eip712_example_with_array_message
+):
+    primary_type = "Mail"
+    expected_hex = (
+        "b19c5c7781083ed7325660d847f8c547b744917d67b38858b00bce7e62a4866bfc71e5fa27ff56c350aa"
+        "531bc129ebdf613b772b6604664f5d8dbe21b85eb0c8cd54f074a4af31b4411ff6a60c9719dbd559c221"
+        "c8ac3492d9d872b041d703d1a88b5e35e8f6bccc3d72ef467ed581615888f8cf34df19d068d04225439b"
+        "e65ab5aadf3154a261abdd9086fc627b61efca26ae5702701d05cd2305f7c52a2fc8"
+    )
+    assert encode_data(primary_type, eip712_example_with_array_types, eip712_example_with_array_message).hex() == expected_hex  # noqa: E501
 
 
-def test_hashed_structured_data(message_encodings):
-    structured_msg = encode_structured_data(**message_encodings)
+def test_hash_struct_main_message_eip712(eip712_example_json_string):
+    structured_data = json.loads(eip712_example_json_string)
+    expected_hex = "c52c0ee5d84264471806290a3f2c4cecfc5490626bf912d01f240d7a274b371e"
+    assert hash_message(structured_data).hex() == expected_hex
+
+
+def test_hash_struct_main_message_eip712_with_array(eip712_example_with_array_json_string):
+    structured_data = json.loads(eip712_example_with_array_json_string)
+    expected_hex = "76649452daa3e4101beef5b01669fd0de45ece35188d529703c73526a2454521"
+    assert hash_message(structured_data).hex() == expected_hex
+
+
+def test_hash_struct_domain_eip712(eip712_example_json_string):
+    structured_data = json.loads(eip712_example_json_string)
+    expected_hex = 'f2cee375fa42b42143804025fc449deafd50cc031ca257e0b194a650a912090f'
+    assert hash_domain(structured_data).hex() == expected_hex
+
+
+def test_hash_struct_domain_eip712_with_array(eip712_example_with_array_json_string):
+    structured_data = json.loads(eip712_example_with_array_json_string)
+    expected_hex = 'f2cee375fa42b42143804025fc449deafd50cc031ca257e0b194a650a912090f'
+    assert hash_domain(structured_data).hex() == expected_hex
+
+
+def test_hashed_structured_data_eip712(eip712_message_encodings):
+    structured_msg = encode_structured_data(**eip712_message_encodings)
     hashed_structured_msg = _hash_eip191_message(structured_msg)
-    expected_hash_value_hex = "4e3c4173651b3054c0635dfae57a3b65ae1527ed0ba9ff76cecb6d9807687a7f"
-    assert hashed_structured_msg.hex() == expected_hash_value_hex
+    expected_hex = 'be609aee343fb3c4b28e1df9e632fca64fcfaede20f02e86244efddf30957bd2'
+    assert hashed_structured_msg.hex() == expected_hex
 
 
-def test_hashed_structured_data_with_bytes(structured_valid_data_json_string):
-    structured_data = json.loads(structured_valid_data_json_string)
+def test_hashed_structured_data_eip127_with_array(eip712_with_array_message_encodings):
+    structured_msg = encode_structured_data(**eip712_with_array_message_encodings)
+    hashed_structured_msg = _hash_eip191_message(structured_msg)
+    expected_hex = '4e3c4173651b3054c0635dfae57a3b65ae1527ed0ba9ff76cecb6d9807687a7f'
+    assert hashed_structured_msg.hex() == expected_hex
+
+
+def test_signature_verification_eip712(eip712_message_encodings):
+    account = Account.create()
+    structured_msg = encode_structured_data(**eip712_message_encodings)
+    signed = Account.sign_message(structured_msg, account.key)
+    new_addr = Account.recover_message(structured_msg, signature=signed.signature)
+    assert new_addr == account.address
+
+
+def test_signature_verification_eip712_with_array(eip712_with_array_message_encodings):
+    account = Account.create()
+    structured_msg = encode_structured_data(**eip712_with_array_message_encodings)
+    signed = Account.sign_message(structured_msg, account.key)
+    new_addr = Account.recover_message(structured_msg, signature=signed.signature)
+    assert new_addr == account.address
+
+
+def test_signature_variables_eip712(eip712_message_encodings):
+    # Check that the signature of typed message is the same as that
+    # mentioned in the EIP. The link is as follows
+    # https://github.com/ethereum/EIPs/blob/master/assets/eip-712/Example.js
+    structured_msg = encode_structured_data(**eip712_message_encodings)
+
+    private_key = keccak(text="cow")
+    acc = Account.from_key(private_key)
+    assert HexBytes(acc.address) == HexBytes("0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826")
+
+    sig = Account.sign_message(structured_msg, private_key)
+    assert sig.v == 28
+    assert hex(sig.r) == "0x4355c47d63924e8a72e509b65029052eb6c299d53a04e167c5775fd466751c9d"
+    assert hex(sig.s) == "0x7299936d304c153f6443dfa05f40ff007d72911b6f72307f996231605b91562"
+
+
+def test_signature_variables_eip712_with_array(eip712_with_array_message_encodings):
+    structured_msg = encode_structured_data(**eip712_with_array_message_encodings)
+
+    private_key = keccak(text="cow")
+    acc = Account.from_key(private_key)
+    assert HexBytes(acc.address) == HexBytes("0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826")
+
+    sig = Account.sign_message(structured_msg, private_key)
+    assert sig.v == 27
+    assert hex(sig.r) == "0x58635e9afd7a2a5338cf2af3d711b50235a1955c43f8bca1657c9d0834fcdb5a"
+    assert hex(sig.s) == "0x44a7c0169616cfdfc16815714c9bc1c94139e17a0761a17530cf3dd1746bc10b"
+
+
+def test_hashed_structured_data_with_bytes(eip712_example_with_array_json_string):
+    structured_data = json.loads(eip712_example_with_array_json_string)
 
     # change 'contents' field to type ``bytes`` and set bytes value
     structured_data['types']['Mail'][3]['type'] = "bytes"
@@ -163,8 +327,8 @@ def test_hashed_structured_data_with_bytes(structured_valid_data_json_string):
     assert hashed_structured_msg.hex() == expected_hash_value_hex
 
 
-def test_hashed_structured_data_with_bytes32(structured_valid_data_json_string):
-    structured_data = json.loads(structured_valid_data_json_string)
+def test_hashed_structured_data_with_bytes32(eip712_example_with_array_json_string):
+    structured_data = json.loads(eip712_example_with_array_json_string)
 
     # change 'contents' field to type ``bytes32`` and set bytes value
     structured_data['types']['Mail'][3]['type'] = "bytes32"
@@ -176,26 +340,17 @@ def test_hashed_structured_data_with_bytes32(structured_valid_data_json_string):
     assert hashed_structured_msg.hex() == expected_hash_value_hex
 
 
-def test_signature_verification(message_encodings):
-    account = Account.create()
-    structured_msg = encode_structured_data(**message_encodings)
-    signed = Account.sign_message(structured_msg, account.key)
-    new_addr = Account.recover_message(structured_msg, signature=signed.signature)
-    assert new_addr == account.address
+def test_hashed_structured_data_with_nested_structs():
+    nested_structs_valid_data_json_string = open(
+        "tests/fixtures/valid_message_nested_structs.json", "r"
+    ).read()
 
+    structured_data = json.loads(nested_structs_valid_data_json_string)
+    structured_msg = encode_structured_data(structured_data)
+    hashed_structured_msg = _hash_eip191_message(structured_msg)
 
-def test_signature_variables(message_encodings):
-    # Check that the signature of typed message is the same as that
-    # mentioned in the EIP. The link is as follows
-    # https://github.com/ethereum/EIPs/blob/master/assets/eip-712/Example.js
-    structured_msg = encode_structured_data(**message_encodings)
-    privateKey = keccak(text="cow")
-    acc = Account.from_key(privateKey)
-    assert HexBytes(acc.address) == HexBytes("0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826")
-    sig = Account.sign_message(structured_msg, privateKey)
-    assert sig.v == 27
-    assert hex(sig.r) == "0x58635e9afd7a2a5338cf2af3d711b50235a1955c43f8bca1657c9d0834fcdb5a"
-    assert hex(sig.s) == "0x44a7c0169616cfdfc16815714c9bc1c94139e17a0761a17530cf3dd1746bc10b"
+    expected_hash_value_hex = "1a9c2ba3822f4f5498e4dfe3593ad69c9135a9f038334b49fa54537cfa9f5244"
+    assert hashed_structured_msg.hex() == expected_hash_value_hex
 
 
 @pytest.mark.parametrize(

--- a/tests/fixtures/valid_eip712_example.json
+++ b/tests/fixtures/valid_eip712_example.json
@@ -13,7 +13,6 @@
 		"Mail": [
 			{"name": "from", "type": "Person"},
 			{"name": "to", "type": "Person"},
-			{"name": "cc", "type": "Person[]"},
 			{"name": "contents", "type": "string"}
 		]
 	},
@@ -33,16 +32,6 @@
 			"name": "Bob",
 			"wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
 		},
-		"cc": [
-      {
-        "name": "Alice",
-        "wallet": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-      },
-      {
-        "name": "Dot",
-        "wallet": "0xdddddddddddddddddddddddddddddddddddddddd"
-      }
-    ],
 		"contents": "Hello, Bob!"
 	}
 }

--- a/tests/fixtures/valid_eip712_example_with_array.json
+++ b/tests/fixtures/valid_eip712_example_with_array.json
@@ -1,0 +1,48 @@
+{
+	"types": {
+		"EIP712Domain": [
+			{"name": "name", "type": "string"},
+			{"name": "version", "type": "string"},
+			{"name": "chainId", "type": "uint256"},
+			{"name": "verifyingContract", "type": "address"}
+		],
+		"Person": [
+			{"name": "name", "type": "string"},
+			{"name": "wallet", "type": "address"}
+		],
+		"Mail": [
+			{"name": "from", "type": "Person"},
+			{"name": "to", "type": "Person"},
+			{"name": "cc", "type": "Person[]"},
+			{"name": "contents", "type": "string"}
+		]
+	},
+	"primaryType": "Mail",
+	"domain": {
+		"name": "Ether Mail",
+		"version": "1",
+		"chainId": 1,
+		"verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+	},
+	"message": {
+		"from": {
+			"name": "Cow",
+			"wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+		},
+		"to": {
+			"name": "Bob",
+			"wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+		},
+		"cc": [
+			{
+				"name": "Alice",
+				"wallet": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			},
+			{
+				"name": "Dot",
+				"wallet": "0xdddddddddddddddddddddddddddddddddddddddd"
+			}
+		],
+		"contents": "Hello, Bob!"
+	}
+}

--- a/tests/fixtures/valid_message_nested_structs.json
+++ b/tests/fixtures/valid_message_nested_structs.json
@@ -1,0 +1,80 @@
+{
+	"types": {
+		"EIP712Domain": [
+			{"name": "name", "type": "string"},
+			{"name": "version", "type": "string"},
+			{"name": "chainId", "type": "uint256"},
+			{"name": "verifyingContract", "type": "address"}
+		],
+		"Owners": [
+			{
+				"name": "owners", "type": "Person[]"
+			}
+		],
+		"Person": [
+			{"name": "name", "type": "string"},
+			{"name": "contract", "type": "Contract"}
+		],
+		"Contract": [
+			{"name": "address", "type": "address"},
+			{"name": "childContracts", "type": "Contract[]"}
+		]
+	},
+	"primaryType": "Owners",
+	"domain": {
+		"name": "Contract Owners",
+		"version": "2",
+		"chainId": 1337,
+		"verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+	},
+	"message": {
+		"owners": [
+			{
+				"name": "Alice",
+				"contract": {
+					"address": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					"childContracts": [
+						{
+							"address": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+							"childContracts": [
+								{
+									"address": "0xcccccccccccccccccccccccccccccccccccccccc",
+									"childContracts": [
+										{
+											"address": "0xabababababababababababababababababababab",
+											"childContracts": []
+										},
+										{
+											"address": "0xacacacacacacacacacacacacacacacacacacacac",
+											"childContracts": []
+										},
+										{
+											"address": "0xadadadadadadadadadadadadadadadadadadadad",
+											"childContracts": [
+												{
+													"address": "0xbabababababababababababababababababababa",
+													"childContracts": []
+												}
+											]
+										},
+										{
+											"address": "0xaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeae",
+											"childContracts": []
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			},
+			{
+				"name": "Bob",
+				"contract": {
+					"address": "0xfefefefefefefefefefefefefefefefefefefefe",
+					"childContracts": []
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
## What was wrong?

- I believe this closes #68 since tuples aren't directly passed in to structured data, only structs.

## How was it fixed?

* Add more robust tests for nested tuples / structs for encode structured data (#68)
* Put back tests that directly test the example from EIP-712 so it can be referenced and checked against actual values if broken
* Refactor tests so that most of the structured data / structured data signing tests test both the EIP-712 example and the updated example with an array

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.reddituploads.com/5f4a92c379e442a88f91c466feacafd5?fit=max&h=1536&w=1536&s=f371772c9454e6e1a17fc1fecaafea11)
