### PR TITLE
remove deprecated methods noted to go in v0.6

### DIFF
--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -581,34 +581,6 @@ class Account:
         return cast(SignedMessage, self._sign_hash(message_hash, private_key))
 
     @combomethod
-    def signHash(self, message_hash, private_key):
-        """
-        Sign the provided hash.
-
-        .. WARNING:: *Never* sign a hash that you didn't generate,
-            it can be an arbitrary transaction. For example, it might
-            send all of your account's ether to an attacker.
-            Instead, prefer :meth:`~eth_account.account.Account.sign_message`,
-            which cannot accidentally sign a transaction.
-
-        .. CAUTION:: Deprecated for :meth:`~eth_account.account.Account.sign_message`.
-            This method will be removed in v0.6
-
-        :param message_hash: the 32-byte message hash to be signed
-        :type message_hash: hex str, bytes or int
-        :param private_key: the key to sign the message with
-        :type private_key: hex str, bytes, int or :class:`eth_keys.datatypes.PrivateKey`
-        :returns: Various details about the signature - most
-          importantly the fields: v, r, and s
-        :rtype: ~eth_account.datastructures.SignedMessage
-        """
-        warnings.warn(
-            "signHash is deprecated in favor of sign_message",
-            category=DeprecationWarning,
-        )
-        return self._sign_hash(message_hash, private_key)
-
-    @combomethod
     def _sign_hash(
         self,
         message_hash: Hash32,

--- a/eth_account/signers/base.py
+++ b/eth_account/signers/base.py
@@ -46,40 +46,6 @@ class BaseAccount(ABC):
         pass
 
     @abstractmethod
-    def signHash(self, message_hash):
-        """
-        Sign the hash of a message.
-
-        This uses the same structure
-        as in :meth:`~eth_account.account.Account.signHash`
-        but without specifying the private key.
-
-        .. CAUTION:: Deprecated for
-            :meth:`~eth_account.signers.base.BaseAccount.sign_message`.
-            To be removed in v0.6
-
-        :param bytes message_hash: 32 byte hash of the message to sign
-        """
-        pass
-
-    @abstractmethod
-    def signTransaction(self, transaction_dict):
-        """
-        Sign a transaction dict.
-
-        This uses the same structure as in
-        :meth:`~eth_account.account.Account.sign_transaction`
-        but without specifying the private key.
-
-        .. CAUTION:: Deprecated for
-            :meth:`~eth_account.account.signers.local.sign_transaction`.
-            This method will be removed in v0.6
-
-        :param dict transaction_dict: transaction with all fields specified
-        """
-        pass
-
-    @abstractmethod
     def sign_transaction(self, transaction_dict):
         """
         Sign a transaction dict.

--- a/newsfragments/196.removal.rst
+++ b/newsfragments/196.removal.rst
@@ -1,0 +1,1 @@
+remove deprecated methods noted to go in v0.6


### PR DESCRIPTION
## What was wrong?

Some deprecated methods were noted to be removed in v0.6.

## How was it fixed?

Remove them

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-account.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/185244770-bf36fb64-06bc-4ccf-9321-8b36285d6f31.png)
