### PR TITLE
Drop `eth-abi` dependency upper bound

### DIFF
--- a/newsfragments/202.misc.rst
+++ b/newsfragments/202.misc.rst
@@ -1,0 +1,1 @@
+Drop upper bound for `eth-abi` dependency, allowing projects dependent on `eth-account` to fine tune their own upper bound for `eth-abi`.

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     },
     install_requires=[
         "bitarray>=2.4.0,<3",
-        "eth-abi>=3.0.0,<4",
+        "eth-abi>=3.0.1",
         "eth-keyfile>=0.6.0,<0.7.0",
         "eth-keys>=0.4.0,<0.5",
         "eth-rlp>=0.3.0,<1",


### PR DESCRIPTION
## What was wrong?

- ``eth-abi 4.0.0-beta.1`` was released with a crucial fix to zero-padding. In an effort to loosen restrictions, and to be able allows projects using `eth-account` to fine tune their own version of `eth-abi`, drop the upper bound of the `eth-abi` dependency.

## How was it fixed?

- Remove upper bound for `eth-abi`; use `>=3.0.1`

### To-Do

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20220926_085357](https://user-images.githubusercontent.com/3532824/192605937-a9279ae7-1bb0-4f6e-92cd-27868c245020.jpg)
