### PR TITLE
add upper pin to hexbytes dep due to incoming breaking update in 0.4.0

### DIFF
--- a/newsfragments/240.internal.rst
+++ b/newsfragments/240.internal.rst
@@ -1,0 +1,1 @@
+Add upper pin to ``hexbytes`` dependency to due incoming breaking change

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         "eth-keys>=0.4.0",
         "eth-rlp>=0.3.0",
         "eth-utils>=2.0.0",
-        "hexbytes>=0.1.0",
+        "hexbytes>=0.1.0,<0.4.0",
         "rlp>=1.0.0",
     ],
     python_requires=">=3.7, <4",


### PR DESCRIPTION
### What was wrong?

The hexbytes lib will be changing the way Hexbytes.hex() works - https://github.com/ethereum/hexbytes/issues/14

### How was it fixed?

Add upper pin to hexbytes dep now, then after next release use hexbytes 0.4.0 as a lower bound.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-account/assets/5199899/eb3aa962-c8bb-4b15-a432-422ab21cfdbf)