### PR TITLE
pin hexbytes>=1.0.0 due to breaking change

### DIFF
--- a/newsfragments/242.internal.rst
+++ b/newsfragments/242.internal.rst
@@ -1,0 +1,1 @@
+Set dependency ``hexbytes>=1.0.0`` due to breaking change there

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         "eth-keys>=0.4.0",
         "eth-rlp>=0.3.0",
         "eth-utils>=2.0.0",
-        "hexbytes>=0.1.0,<0.4.0",
+        "hexbytes>=1.0.0",
         "rlp>=1.0.0",
     ],
     python_requires=">=3.7, <4",


### PR DESCRIPTION
### What was wrong?

`hexbytes` had a breaking change in the step from `0.3.x` to `1.0.0`. `hexbytes` was capped at `<0.4.0` in the previous `eth-account` release. 

### How was it fixed?

This pr sets dependency to `hexbytes>=1.0.0`.

Related to https://github.com/ethereum/hexbytes/pull/38/files

### Todo:
- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-account/assets/5199899/ee6435f6-0d48-4ab5-8a04-d00a92f79025)