### PR TITLE
update SignableMessage comment

### DIFF
--- a/247.docs.rst
+++ b/247.docs.rst
@@ -1,0 +1,1 @@
+Add ``encode_typed_data`` to list of functions that return a ``SignableMessage``

--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -61,6 +61,7 @@ class SignableMessage(NamedTuple):
         - :meth:`encode_structured_data`
         - :meth:`encode_intended_validator`
         - :meth:`encode_defunct`
+        - :meth:`encode_typed_data`
 
     .. _EIP-191: https://eips.ethereum.org/EIPS/eip-191
     """


### PR DESCRIPTION
### What was wrong?

The `encode_typed_data` also return signable message, but the documentation wasn't mentioned it. 

Related to Issue #
Closes #

### How was it fixed?

In this PR, I added `encode_typed_data` in the comment.

### Todo:
- [ ] Clean up commit history

- [ ] Add or update documentation related to these changes

- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()