### PR TITLE
Import toolz functions from eth_utils

### DIFF
--- a/eth_account/_utils/legacy_transactions.py
+++ b/eth_account/_utils/legacy_transactions.py
@@ -3,18 +3,18 @@ from typing import (
     Dict,
 )
 
-from cytoolz import (
-    curry,
-    dissoc,
-    merge,
-    partial,
-    pipe,
-)
 from eth_rlp import (
     HashableRLP,
 )
 from eth_utils.curried import (
     apply_formatters_to_dict,
+)
+from eth_utils.toolz import (
+    curry,
+    dissoc,
+    merge,
+    partial,
+    pipe,
 )
 import rlp
 from rlp.sedes import (

--- a/eth_account/_utils/signing.py
+++ b/eth_account/_utils/signing.py
@@ -1,9 +1,9 @@
-from cytoolz import (
-    pipe,
-)
 from eth_utils import (
     to_bytes,
     to_int,
+)
+from eth_utils.toolz import (
+    pipe,
 )
 
 from eth_account._utils.legacy_transactions import (

--- a/eth_account/_utils/typed_transactions.py
+++ b/eth_account/_utils/typed_transactions.py
@@ -10,13 +10,6 @@ from typing import (
     cast,
 )
 
-from cytoolz import (
-    dissoc,
-    identity,
-    merge,
-    partial,
-    pipe,
-)
 from eth_rlp import (
     HashableRLP,
 )
@@ -32,6 +25,13 @@ from eth_utils.curried import (
     is_string,
     to_bytes,
     to_int,
+)
+from eth_utils.toolz import (
+    dissoc,
+    identity,
+    merge,
+    partial,
+    pipe,
 )
 from hexbytes import (
     HexBytes,

--- a/eth_account/_utils/validation.py
+++ b/eth_account/_utils/validation.py
@@ -1,6 +1,3 @@
-from cytoolz import (
-    identity,
-)
 from eth_utils import (
     is_binary_address,
     is_checksum_address,
@@ -17,6 +14,9 @@ from eth_utils.curried import (
     is_string,
     to_bytes,
     to_int,
+)
+from eth_utils.toolz import (
+    identity,
 )
 
 VALID_EMPTY_ADDRESSES = {None, b"", ""}

--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -14,9 +14,6 @@ from typing import (
 )
 import warnings
 
-from cytoolz import (
-    dissoc,
-)
 from eth_keyfile import (
     create_keyfile_json,
     decode_keyfile_json,
@@ -41,6 +38,9 @@ from eth_utils.curried import (
     text_if_str,
     to_bytes,
     to_int,
+)
+from eth_utils.toolz import (
+    dissoc,
 )
 from hexbytes import (
     HexBytes,

--- a/newsfragments/251.bugfix.rst
+++ b/newsfragments/251.bugfix.rst
@@ -1,0 +1,1 @@
+Import cytoolz methods via eth_utils instead of cytoolz directly

--- a/tests/core/test_accounts.py
+++ b/tests/core/test_accounts.py
@@ -1,8 +1,5 @@
 import os
 
-from cytoolz import (
-    dissoc,
-)
 from eth_keyfile.keyfile import (
     get_default_work_factor_for_kdf,
 )
@@ -14,6 +11,9 @@ from eth_utils import (
     to_bytes,
     to_hex,
     to_int,
+)
+from eth_utils.toolz import (
+    dissoc,
 )
 from hexbytes import (
     HexBytes,

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -1,9 +1,9 @@
-from cytoolz import (
-    assoc,
-    dissoc,
-)
 from eth_abi.exceptions import (
     ABITypeError,
+)
+from eth_utils.toolz import (
+    assoc,
+    dissoc,
 )
 import pytest
 


### PR DESCRIPTION
### What was wrong?
There were a few imports from cytoolz, which this lib doesn't directly require. 

Related to Issue #215 
Closes #216, Closes #250

### How was it fixed?
Moved around the imports. 

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://thumbs.dreamstime.com/b/adorable-fuzzy-baby-yak-playful-293464871.jpg)
