### PR TITLE
Remove signHash in favor of unsafe_sign_hash

### DIFF
--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -12,7 +12,6 @@ from typing import (
     Union,
     cast,
 )
-import warnings
 
 from eth_keyfile import (
     create_keyfile_json,
@@ -582,7 +581,7 @@ class Account:
         return cast(SignedMessage, self._sign_hash(message_hash, private_key))
 
     @combomethod
-    def signHash(self, message_hash, private_key):
+    def unsafe_sign_hash(self, message_hash, private_key):
         """
         Sign the provided hash.
 
@@ -592,9 +591,6 @@ class Account:
             Instead, prefer :meth:`~eth_account.account.Account.sign_message`,
             which cannot accidentally sign a transaction.
 
-        .. CAUTION:: Deprecated for :meth:`~eth_account.account.Account.sign_message`.
-            This method will be removed in v0.6
-
         :param message_hash: the 32-byte message hash to be signed
         :type message_hash: hex str, bytes or int
         :param private_key: the key to sign the message with
@@ -603,11 +599,6 @@ class Account:
           importantly the fields: v, r, and s
         :rtype: ~eth_account.datastructures.SignedMessage
         """
-        warnings.warn(
-            "signHash is deprecated in favor of sign_message",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
         return self._sign_hash(message_hash, private_key)
 
     @combomethod

--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -331,8 +331,8 @@ def defunct_hash_message(
     """
     Convert the provided message into a message hash, to be signed.
 
-    .. CAUTION:: Intended for use with the deprecated
-        :meth:`eth_account.account.Account.signHash`.
+    .. CAUTION:: Intended for use with
+        :meth:`eth_account.account.Account.unsafe_sign_hash`.
         This is for backwards compatibility only. All new implementations
         should use :meth:`encode_defunct` instead.
 

--- a/eth_account/signers/base.py
+++ b/eth_account/signers/base.py
@@ -48,6 +48,12 @@ class BaseAccount(ABC):
         """
         Sign the hash of a message.
 
+        .. WARNING:: *Never* sign a hash that you didn't generate,
+            it can be an arbitrary transaction. For example, it might
+            send all of your account's ether to an attacker.
+            Instead, prefer :meth:`~eth_account.account.Account.sign_message`,
+            which cannot accidentally sign a transaction.
+
         This uses the same structure
         as in :meth:`~eth_account.account.Account.unsafe_sign_hash`
         but without specifying the private key.

--- a/eth_account/signers/base.py
+++ b/eth_account/signers/base.py
@@ -44,17 +44,13 @@ class BaseAccount(ABC):
         """
 
     @abstractmethod
-    def signHash(self, message_hash):
+    def unsafe_sign_hash(self, message_hash):
         """
         Sign the hash of a message.
 
         This uses the same structure
-        as in :meth:`~eth_account.account.Account.signHash`
+        as in :meth:`~eth_account.account.Account.unsafe_sign_hash`
         but without specifying the private key.
-
-        .. CAUTION:: Deprecated for
-            :meth:`~eth_account.signers.base.BaseAccount.sign_message`.
-            To be removed in v0.6
 
         :param bytes message_hash: 32 byte hash of the message to sign
         """

--- a/eth_account/signers/local.py
+++ b/eth_account/signers/local.py
@@ -64,8 +64,8 @@ class LocalAccount(BaseAccount):
             self.key, password, kdf=kdf, iterations=iterations
         )
 
-    def signHash(self, message_hash):
-        return self._publicapi.signHash(
+    def unsafe_sign_hash(self, message_hash):
+        return self._publicapi.unsafe_sign_hash(
             message_hash,
             private_key=self.key,
         )

--- a/newsfragments/260.removal.rst
+++ b/newsfragments/260.removal.rst
@@ -1,0 +1,1 @@
+Remove ``signHash`` in favor of ``unsafe_sign_hash``

--- a/tests/core/test_accounts.py
+++ b/tests/core/test_accounts.py
@@ -402,8 +402,7 @@ def test_eth_account_hash_message_hexstr(acct, message, expected):
 def test_sign_message_against_sign_hash_as_text(keyed_acct, message_text):
     # sign via hash
     msg_hash = defunct_hash_message(text=message_text)
-    with pytest.deprecated_call():
-        signed_via_hash = keyed_acct.signHash(msg_hash)
+    signed_via_hash = keyed_acct.unsafe_sign_hash(msg_hash)
 
     # sign via message
     signable_message = encode_defunct(text=message_text)
@@ -415,8 +414,7 @@ def test_sign_message_against_sign_hash_as_text(keyed_acct, message_text):
 def test_sign_message_against_sign_hash_as_bytes(keyed_acct, message_bytes):
     # sign via hash
     msg_hash = defunct_hash_message(message_bytes)
-    with pytest.deprecated_call():
-        signed_via_hash = keyed_acct.signHash(msg_hash)
+    signed_via_hash = keyed_acct.unsafe_sign_hash(msg_hash)
 
     # sign via message
     signable_message = encode_defunct(message_bytes)
@@ -431,8 +429,7 @@ def test_sign_message_against_sign_hash_as_hex(keyed_acct, message_bytes):
 
     # sign via hash
     msg_hash_hex = defunct_hash_message(hexstr=message_hex)
-    with pytest.deprecated_call():
-        signed_via_hash_hex = keyed_acct.signHash(msg_hash_hex)
+    signed_via_hash_hex = keyed_acct.unsafe_sign_hash(msg_hash_hex)
 
     # sign via message
     signable_message_hex = encode_defunct(hexstr=message_hex)


### PR DESCRIPTION
### What was wrong?
It's not safe to sign random hashes, but occasionally developers want to do so. We were undecided about what to do with the method, but decided to add a new method called `unsafe_sign_hash` and finally remove `signHash`


Closes #85

### How was it fixed?
Removed `signHash`, moved functionality to `unsafe_sign_hash`.

LMK if you think we should add more/different docs

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://live.staticflickr.com/7054/27243655901_f35ae49ee0_b.jpg)
