### PR TITLE
Deprecate messageHash

### DIFF
--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -569,6 +569,7 @@ class Account:
             >>> key = "0xb25c7db31feed9122727bf0939dc769a96564b2de4c4726d035b36ecf1e5b364"
             >>> Account.sign_message(msghash, key)
             SignedMessage(messageHash=HexBytes('0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750'),
+             message_hash=HexBytes('0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750'),
              r=104389933075820307925104709181714897380569894203213074526835978196648170704563,
              s=28205917190874851400050446352651915501321657673772411533993420917949420456142,
              v=28,
@@ -625,6 +626,7 @@ class Account:
         (v, r, s, eth_signature_bytes) = sign_message_hash(key, msg_hash_bytes)
         return SignedMessage(
             messageHash=msg_hash_bytes,
+            message_hash=msg_hash_bytes,
             r=r,
             s=s,
             v=v,
@@ -917,7 +919,7 @@ class Account:
             ... }
             >>> key = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
             >>> signed_message = Account.sign_typed_data(key, domain_data, message_types, message_data)
-            >>> signed_message.messageHash
+            >>> signed_message.message_hash
             HexBytes('0xc5bb16ccc59ae9a3ad1cb8343d4e3351f057c994a97656e1aff8c134e56f7530')
 
             >>> # 1-argument usage
@@ -963,7 +965,7 @@ class Account:
             ...     },
             ... }
             >>> signed_message_2 = Account.sign_typed_data(key, full_message=full_message)
-            >>> signed_message_2.messageHash
+            >>> signed_message_2.message_hash
             HexBytes('0xc5bb16ccc59ae9a3ad1cb8343d4e3351f057c994a97656e1aff8c134e56f7530')
             >>> signed_message_2 == signed_message
             True

--- a/eth_account/datastructures.py
+++ b/eth_account/datastructures.py
@@ -1,6 +1,7 @@
 from typing import (
     NamedTuple,
 )
+import warnings
 
 from hexbytes import (
     HexBytes,
@@ -25,12 +26,35 @@ class SignedTransaction(NamedTuple):
         return __getitem__(self, index)
 
 
-class SignedMessage(NamedTuple):
+class SignedMessage(
+    NamedTuple(
+        "SignedMessage",
+        [
+            ("messageHash", HexBytes),
+            ("message_hash", HexBytes),
+            ("r", int),
+            ("s", int),
+            ("v", int),
+            ("signature", HexBytes),
+        ],
+    )
+):
     messageHash: HexBytes
+    message_hash: HexBytes
     r: int
     s: int
     v: int
     signature: HexBytes
+
+    def __getattribute__(cls, name):
+        if name == "messageHash":
+            warnings.warn(
+                "The attribute messageHash on SignedMessage is deprecated "
+                "in favor of message_hash",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return super().__getattribute__(name)
 
     def __getitem__(self, index):
         return __getitem__(self, index)

--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -229,7 +229,7 @@ def encode_structured_data(
 
         >>> signed_msg_from_dict == signed_msg_from_str == signed_msg_from_hexstr
         True
-        >>> signed_msg_from_dict.messageHash
+        >>> signed_msg_from_dict.message_hash
         HexBytes('0xbe609aee343fb3c4b28e1df9e632fca64fcfaede20f02e86244efddf30957bd2')
 
     .. _EIP-712: https://eips.ethereum.org/EIPS/eip-712
@@ -443,7 +443,7 @@ def encode_typed_data(
         >>> key = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         >>> signable_message = encode_typed_data(domain_data, message_types, message_data)
         >>> signed_message = Account.sign_message(signable_message, key)
-        >>> signed_message.messageHash
+        >>> signed_message.message_hash
         HexBytes('0xc5bb16ccc59ae9a3ad1cb8343d4e3351f057c994a97656e1aff8c134e56f7530')
         >>> # the message can be signed in one step using Account.sign_typed_data
         >>> signed_typed_data = Account.sign_typed_data(key, domain_data, message_types, message_data)
@@ -494,7 +494,7 @@ def encode_typed_data(
         ... }
         >>> signable_message_2 = encode_typed_data(full_message=full_message)
         >>> signed_message_2 = Account.sign_message(signable_message_2, key)
-        >>> signed_message_2.messageHash
+        >>> signed_message_2.message_hash
         HexBytes('0xc5bb16ccc59ae9a3ad1cb8343d4e3351f057c994a97656e1aff8c134e56f7530')
         >>> signed_message_2 == signed_message
         True

--- a/newsfragments/264.deprecation.rst
+++ b/newsfragments/264.deprecation.rst
@@ -1,0 +1,1 @@
+Deprecated messageHash in favor of message_hash on SignedMessage

--- a/tests/core/test_accounts.py
+++ b/tests/core/test_accounts.py
@@ -502,7 +502,12 @@ def test_eth_account_sign(
 ):
     signable = encode_defunct(text=message)
     signed = acct.sign_message(signable, private_key=key)
-    assert signed.messageHash == signed["messageHash"] == expected_hash
+    with pytest.warns(
+        DeprecationWarning,
+        match="messageHash on SignedMessage is deprecated in favor of message_hash",
+    ):
+        assert signed.messageHash == signed["messageHash"] == expected_hash
+    assert signed.message_hash == signed["message_hash"] == expected_hash
     assert signed.v == signed["v"] == v
     assert signed.r == signed["r"] == r
     assert signed.s == signed["s"] == s


### PR DESCRIPTION
### What was wrong?
messageHash is a remnant of camelCasing.

Related to Issue #176 

### How was it fixed?
Added a `DeprecationWarning` when users try to access `messageHash`, added a `message_hash` attribute to `SignedMessage` so folks can upgrade.

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/76/08/65/7608656b496b77a1bc1df0df561ba50d.jpg)
