### PR TITLE
Deprecate rawTransaction

### DIFF
--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -710,8 +710,13 @@ class Account:
             >>> key = '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318'
             >>> signed_df_tx = Account.sign_transaction(dynamic_fee_transaction, key)
             >>> signed_df_tx
-            SignedTransaction(rawTransaction=HexBytes('0x02f8b28205392284773594008477359400830186a09409616c3d61b3331fc4109a9e41a8bdb7d9776609865af3107...d58b85d5'), hash=HexBytes('0x2721b2ac99d878695e410af9e8968859b6f6e94f544840be0eb2935bead7deba'), r=48949965662841329840326477994465373664672499148507933176648302825256944281697, s=1123041608316060268133200864147951676126406077675157976022772782796802590165, v=1)
-            >>> w3.eth.sendRawTransaction(signed_df_tx.rawTransaction)  # doctest: +SKIP
+            SignedTransaction(rawTransaction=HexBytes('0x02f8b28205392284773594008477359400830186a09409616c3d61b3331fc4109a9e41a8bdb7d9776609865af3107...d58b85d5'),
+             raw_transaction=HexBytes('0x02f8b28205392284773594008477359400830186a09409616c3d61b3331fc4109a9e41a8bdb7d9776609865af3107...d58b85d5'),
+             hash=HexBytes('0x2721b2ac99d878695e410af9e8968859b6f6e94f544840be0eb2935bead7deba'),
+             r=48949965662841329840326477994465373664672499148507933176648302825256944281697,
+             s=1123041608316060268133200864147951676126406077675157976022772782796802590165,
+             v=1)
+            >>> w3.eth.sendRawTransaction(signed_df_tx.raw_transaction)  # doctest: +SKIP
 
         .. doctest:: python
 
@@ -729,8 +734,13 @@ class Account:
             >>> key = '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318'
             >>> signed_legacy_tx = Account.sign_transaction(legacy_transaction, key)
             >>> signed_legacy_tx
-            SignedTransaction(rawTransaction=HexBytes('0xf86c8086d55698372431831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca0080820a95a01a7...c0bfdb52'), hash=HexBytes('0xd0a3e5dc7439f260c64cb0220139ec5dc7e016f82ce272a25a0f0b38fe751673'), r=11971260903864915610009019893820767192081275151191539081612245320300335068143, s=35365272040292958794699923036506252105590820339897221552886630515981233937234, v=2709)
-            >>> w3.eth.sendRawTransaction(signed_legacy_tx.rawTransaction)  # doctest: +SKIP
+            SignedTransaction(rawTransaction=HexBytes('0xf86c8086d55698372431831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca0080820a95a01a7...c0bfdb52'),
+             raw_transaction=HexBytes('0xf86c8086d55698372431831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca0080820a95a01a7...c0bfdb52'),
+             hash=HexBytes('0xd0a3e5dc7439f260c64cb0220139ec5dc7e016f82ce272a25a0f0b38fe751673'),
+             r=11971260903864915610009019893820767192081275151191539081612245320300335068143,
+             s=35365272040292958794699923036506252105590820339897221552886630515981233937234,
+             v=2709)
+            >>> w3.eth.sendRawTransaction(signed_legacy_tx.raw_transaction)  # doctest: +SKIP
 
         .. doctest:: python
 
@@ -756,8 +766,13 @@ class Account:
             >>> key = '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318'
             >>> signed_al_tx = Account.sign_transaction(access_list_transaction, key)
             >>> signed_al_tx
-            SignedTransaction(rawTransaction=HexBytes('0x01f8ad82053922843b9aca00830186a09409616c3d61b3331fc4109a9e41a8bdb7d9776609865af3107a400086616...2b5043ea'), hash=HexBytes('0xca9af2ef41691e06eb07e02125938fd9bb5a311e8daf330b264e77d6cdf3d17e'), r=107355854401379915513092408112372039746594668141865279802319959599514133709188, s=6729502936685237038651223791038758905953302464070244934323623239104475448298, v=1)
-            >>> w3.eth.sendRawTransaction(signed_al_tx.rawTransaction)  # doctest: +SKIP
+            SignedTransaction(rawTransaction=HexBytes('0x01f8ad82053922843b9aca00830186a09409616c3d61b3331fc4109a9e41a8bdb7d9776609865af3107a400086616...2b5043ea'),
+             raw_transaction=HexBytes('0x01f8ad82053922843b9aca00830186a09409616c3d61b3331fc4109a9e41a8bdb7d9776609865af3107a400086616...2b5043ea'),
+             hash=HexBytes('0xca9af2ef41691e06eb07e02125938fd9bb5a311e8daf330b264e77d6cdf3d17e'),
+             r=107355854401379915513092408112372039746594668141865279802319959599514133709188,
+             s=6729502936685237038651223791038758905953302464070244934323623239104475448298,
+             v=1)
+            >>> w3.eth.sendRawTransaction(signed_al_tx.raw_transaction)  # doctest: +SKIP
 
         .. doctest:: python
 
@@ -788,8 +803,13 @@ class Account:
             >>> # The `blobVersionedHashes` transaction field is calculated from the `blobs` kwarg
             >>> signed_blob_tx = Account.sign_transaction(blob_transaction, key, blobs=[empty_blob])
             >>> signed_blob_tx
-            SignedTransaction(rawTransaction=HexBytes('0x03fa020147f8d98205392284773594008477359400830186a09409616c3d61b3331fc4109a9e41a8bdb7d97766098...00000000'), hash=HexBytes('0xf9dc8867c4324fd7f4506622aa700989562770f01d7d681cef74a1a1deb9fea9'), r=14319949980593194209648175507603206696573324965145502821772573913457715875718, s=9129184742597516615341309773045281461399831333162885393648678700392065987233, v=1)
-            >>> w3.eth.sendRawTransaction(signed_blob_tx.rawTransaction)  # doctest: +SKIP
+            SignedTransaction(rawTransaction=HexBytes('0x03fa020147f8d98205392284773594008477359400830186a09409616c3d61b3331fc4109a9e41a8bdb7d97766098...00000000'),
+             raw_transaction=HexBytes('0x03fa020147f8d98205392284773594008477359400830186a09409616c3d61b3331fc4109a9e41a8bdb7d97766098...00000000'),
+             hash=HexBytes('0xf9dc8867c4324fd7f4506622aa700989562770f01d7d681cef74a1a1deb9fea9'),
+             r=14319949980593194209648175507603206696573324965145502821772573913457715875718,
+             s=9129184742597516615341309773045281461399831333162885393648678700392065987233,
+             v=1)
+            >>> w3.eth.sendRawTransaction(signed_blob_tx.raw_transaction)  # doctest: +SKIP
         """  # noqa: E501
         if not isinstance(transaction_dict, Mapping):
             raise TypeError(
@@ -821,6 +841,7 @@ class Account:
 
         return SignedTransaction(
             rawTransaction=HexBytes(encoded_transaction),
+            raw_transaction=HexBytes(encoded_transaction),
             hash=HexBytes(transaction_hash),
             r=r,
             s=s,

--- a/eth_account/datastructures.py
+++ b/eth_account/datastructures.py
@@ -15,12 +15,35 @@ def __getitem__(self, index):
         return getattr(self, index)
 
 
-class SignedTransaction(NamedTuple):
+class SignedTransaction(
+    NamedTuple(
+        "SignedTransaction",
+        [
+            ("rawTransaction", HexBytes),
+            ("raw_transaction", HexBytes),
+            ("hash", HexBytes),
+            ("r", int),
+            ("s", int),
+            ("v", int),
+        ],
+    )
+):
     rawTransaction: HexBytes
+    raw_transaction: HexBytes
     hash: HexBytes
     r: int
     s: int
     v: int
+
+    def __getattribute__(cls, name):
+        if name == "rawTransaction":
+            warnings.warn(
+                "The attribute rawTransaction on SignedTransaction is deprecated "
+                "in favor of raw_transaction",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return super().__getattribute__(name)
 
     def __getitem__(self, index):
         return __getitem__(self, index)

--- a/newsfragments/266.deprecation.rst
+++ b/newsfragments/266.deprecation.rst
@@ -1,0 +1,1 @@
+Deprecate ``SignedTransaction``'s ``rawTransaction`` attribute in favor of ``raw_transaction``

--- a/tests/core/test_accounts.py
+++ b/tests/core/test_accounts.py
@@ -716,7 +716,13 @@ def test_eth_account_sign_transaction(
     assert signed.r == signed["r"] == r
     assert signed.s == signed["s"] == s
     assert signed.v == signed["v"] == v
-    assert signed.rawTransaction == signed["rawTransaction"] == expected_raw_tx
+    with pytest.warns(
+        DeprecationWarning,
+        match="rawTransaction on SignedTransaction is deprecated in favor "
+        "of raw_transaction",
+    ):
+        assert signed.rawTransaction == signed["rawTransaction"] == expected_raw_tx
+    assert signed.raw_transaction == signed["raw_transaction"] == expected_raw_tx
     assert signed.hash == signed["hash"] == tx_hash
 
     account = acct.from_key(private_key)
@@ -743,7 +749,7 @@ def test_eth_account_sign_transaction_from_eth_test(acct, transaction):
 
     # confirm that signed transaction can be recovered to the sender
     expected_sender = acct.from_key(key).address
-    assert acct.recover_transaction(signed.rawTransaction) == expected_sender
+    assert acct.recover_transaction(signed.raw_transaction) == expected_sender
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_blob_transactions.py
+++ b/tests/core/test_blob_transactions.py
@@ -98,7 +98,7 @@ def test_sign_blob_transaction_with_zero_blob_and_compare_with_tx_from_bytes():
         signed_tx_from_file = to_bytes(hexstr=signed_tx_file.read().strip("\n"))
 
     signed_tx = TEST_ACCT.sign_transaction(BLOB_TX_DICT, blobs=[ZERO_BLOB])
-    assert signed_tx.rawTransaction == HexBytes(signed_tx_from_file)
+    assert signed_tx.raw_transaction == HexBytes(signed_tx_from_file)
 
     # test `from_bytes()` creates `blob_data`
     tx_from_bytes = BlobTransaction.from_bytes(HexBytes(signed_tx_from_file))
@@ -150,7 +150,7 @@ def test_blob_transaction_calculation_with_nonzero_blob():
         blob_data_1_signed = to_bytes(hexstr=blob_data_1_signed_file.read().strip("\n"))
 
     signed = TEST_ACCT.sign_transaction(tx.dictionary, blobs=[blob_data_1])
-    assert blob_data_1_signed == signed.rawTransaction
+    assert blob_data_1_signed == signed.raw_transaction
 
 
 def test_high_and_low_blob_count_limit_validation():


### PR DESCRIPTION
### What was wrong?
rawTransaction is a camelCase remnant. Deprecated here to remove in v0.13.x.

Closes #176 

### How was it fixed?
Added a deprecation warning to `__getattribute__`, and added `raw_transaction` attribute.

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.shutterstock.com/image-photo/baby-margay-260nw-1170724513.jpg)
