### PR TITLE
move _parsePrivateKey to _parse_private_key

### DIFF
--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -262,7 +262,7 @@ class Account:
             # encrypt(). They correspond to the same-named methods in Account.*
             # but without the private key argument
         """
-        key = self._parsePrivateKey(private_key)
+        key = self._parse_private_key(private_key)
         return LocalAccount(key, self)
 
     @combomethod
@@ -335,7 +335,7 @@ class Account:
             )
         seed = seed_from_mnemonic(mnemonic, passphrase)
         private_key = key_from_seed(seed, account_path)
-        key = self._parsePrivateKey(private_key)
+        key = self._parse_private_key(private_key)
         return LocalAccount(key, self)
 
     @combomethod
@@ -611,7 +611,7 @@ class Account:
         if len(msg_hash_bytes) != 32:
             raise ValueError("The message hash must be exactly 32-bytes")
 
-        key = self._parsePrivateKey(private_key)
+        key = self._parse_private_key(private_key)
 
         (v, r, s, eth_signature_bytes) = sign_message_hash(key, msg_hash_bytes)
         return SignedMessage(
@@ -794,7 +794,7 @@ class Account:
         )
 
     @combomethod
-    def _parsePrivateKey(self, key):
+    def _parse_private_key(self, key):
         """
         Generate a :class:`eth_keys.datatypes.PrivateKey` from the provided key.
 

--- a/newsfragments/267.removal.rst
+++ b/newsfragments/267.removal.rst
@@ -1,0 +1,1 @@
+Moved private ``_parsePrivateKey`` method to ``_parse_private_key``


### PR DESCRIPTION
### What was wrong?

More camelCase methods. This one is private, so no deprecation needed. 

### How was it fixed?

`_parsePrivateKey` -> `_parse_private_key`

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/vu6etnt26b551.png)
