### PR TITLE
Open up Pydantic requirement

### DIFF
--- a/newsfragments/271.bugfix.rst
+++ b/newsfragments/271.bugfix.rst
@@ -1,0 +1,1 @@
+Open up Pydantic dependency

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         "hexbytes>=1.2.0",
         "rlp>=1.0.0",
         "ckzg>=0.4.3",
-        "pydantic>=2.4.0",
+        "pydantic>=2.0.0",
     ],
     python_requires=">=3.8, <4",
     extras_require=extras_require,


### PR DESCRIPTION
### What was wrong?
We can open up the Pydantic requirement a little, so we should.

Inspired by #270, but doesn't fix it.

### How was it fixed?
Opened up the range.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/the-worlds-smallest-monkey-the-pygmy-marmoset-these-monkeys-v0-0h4odod1n9x91.jpg?width=498&format=pjpg&auto=webp&s=2ac244c03592e1d34b751be355f466e383fce56f)
