### PR TITLE
bugfix: revert pydantic dependency introduction

### DIFF
--- a/newsfragments/272.bugfix.rst
+++ b/newsfragments/272.bugfix.rst
@@ -1,0 +1,1 @@
+Revert the introduction of ``pydantic`` as a dependency within the ``0.11.x`` version.

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
         "hexbytes>=0.1.0,<0.4.0",
         "rlp>=1.0.0",
         "ckzg>=0.4.3",
-        "pydantic>=2.4.0",
     ],
     python_requires=">=3.8, <4",
     extras_require=extras_require,


### PR DESCRIPTION
### What was wrong?

- The introduction of ``pydantic`` as a dependency in `0.11.x` was not necessary and it was not appropriate for a patch release (see issue ethereum/eth-account#270). This is simple enough to remove for `0.11.x` and leave it for `0.12.x`.

Related to Issue #270

### How was it fixed?

- Revert the use of `pydantic` as a dependency. This is simple enough to handle by defining `__init__()` methods that validate inputs to the `data` coming into each of the blob class objects.

---
Note: By removing `pydantic`, we don't validate the input's `type` in the data models but this should be consistent with the rest of the library up to `0.11.0`. That's one additional benefit we get from the `pydantic` implementation in `0.12.x`.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="1114" alt="Screenshot 2024-04-08 at 13 32 52" src="https://github.com/ethereum/eth-account/assets/3532824/c761c532-7cfc-4e68-8a6c-b47fb847b3ee">
