### PR TITLE
Expand pydantic dependency requirement

### DIFF
--- a/newsfragments/272.bugfix.rst
+++ b/newsfragments/272.bugfix.rst
@@ -1,0 +1,1 @@
+Expand valid Pydantic versions

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         "hexbytes>=1.2.0",
         "rlp>=1.0.0",
         "ckzg>=0.4.3",
-        "pydantic>=2.4.0",
+        "pydantic>=2.0.0",
     ],
     python_requires=">=3.8, <4",
     extras_require=extras_require,


### PR DESCRIPTION
### What was wrong?
There is no reason to disallow versions of Pydantic less than 2.4.

### How was it fixed?
Expanded the requirement.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://img.huffingtonpost.com/asset/5cd3ac0a2400005500a9b10f.jpeg?ops=1778_1000)
