### PR TITLE
fix docs ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,14 +86,32 @@ windows-wheel-steps:
       key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 docs: &docs
-  docker:
-    - image: common
+  working_directory: ~/repo
   steps:
+    - checkout
+    - restore_cache:
+        keys:
+          - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+    - run:
+        name: install dependencies
+        command: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
     - run:
         name: install latexpdf dependencies
         command: |
           sudo apt-get update
-          sudo apt-get install latexmk tex-gyre texlive-fonts-extra
+          sudo apt-get install latexmk tex-gyre texlive-fonts-extra texlive-xetex xindy
+    - run:
+        name: run tox
+        command: python -m tox run -r
+    - save_cache:
+        paths:
+          - .tox
+          - ~/.cache/pip
+          - ~/.local
+        key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+  resource_class: xlarge
 
 integration: &integration
   working_directory: ~/repo

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -196,6 +196,8 @@ htmlhelp_basename = "eth_accountdocs"
 
 # -- Options for LaTeX output ---------------------------------------------
 
+latex_engine = "xelatex"
+
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #'papersize': 'letterpaper',

--- a/newsfragments/275.misc.rst
+++ b/newsfragments/275.misc.rst
@@ -1,0 +1,1 @@
+Fix docs CI - it was only installing deps, not actually running tox. Updated latex build engine to xelatex.


### PR DESCRIPTION
### What was wrong?

Fix docs CI - it was only installing deps, not actually running tox

`eth-account` uses a unicode character - ♥ - that was not supported by the existing latex docs build tools, so updated the latex build engine too.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-account/assets/5199899/2de9b4ec-0992-4403-aeaf-a747bf4a6774)
