### PR TITLE
Set remaining mypy setting to true

### DIFF
--- a/eth_account/_utils/legacy_transactions.py
+++ b/eth_account/_utils/legacy_transactions.py
@@ -179,7 +179,8 @@ def chain_id_to_v(transaction_dict: TransactionDictType) -> Dict[str, Any]:
         return dict(transaction_dict, v=chain_id, r=0, s=0)
 
 
-@curry
+# type ignored because curry doesn't preserve typing
+@curry  # type: ignore[misc]
 def fill_transaction_defaults(
     transaction_dict: TransactionDictType,
 ) -> TransactionDictType:

--- a/eth_account/_utils/transaction_utils.py
+++ b/eth_account/_utils/transaction_utils.py
@@ -2,6 +2,7 @@ from typing import (
     Any,
     Dict,
     Sequence,
+    Tuple,
 )
 
 from toolz import (
@@ -74,7 +75,9 @@ def transaction_rpc_to_rlp_structure(dictionary: Dict[str, Any]) -> Dict[str, An
     return dictionary
 
 
-def _access_list_rpc_to_rlp_structure(access_list: Sequence) -> Sequence:
+def _access_list_rpc_to_rlp_structure(
+    access_list: Sequence[Dict[str, Any]]
+) -> Tuple[Tuple[str, Tuple[str]], ...]:
     if not is_rpc_structured_access_list(access_list):
         raise ValueError(
             "provided object not formatted as JSON-RPC-structured access list"
@@ -104,7 +107,9 @@ def transaction_rlp_to_rpc_structure(dictionary: Dict[str, Any]) -> Dict[str, An
     return dictionary
 
 
-def _access_list_rlp_to_rpc_structure(access_list: Sequence) -> Sequence:
+def _access_list_rlp_to_rpc_structure(
+    access_list: Sequence[Any],
+) -> Sequence[Dict[str, Any]]:
     if not is_rlp_structured_access_list(access_list):
         raise ValueError("provided object not formatted as rlp-structured access list")
 

--- a/eth_account/_utils/transaction_utils.py
+++ b/eth_account/_utils/transaction_utils.py
@@ -1,8 +1,6 @@
 from typing import (
     Any,
     Dict,
-    Sequence,
-    Tuple,
 )
 
 from toolz import (
@@ -15,6 +13,8 @@ from eth_account._utils.validation import (
     is_rpc_structured_access_list,
 )
 from eth_account.types import (
+    AccessList,
+    RLPStructuredAccessList,
     TransactionDictType,
 )
 
@@ -76,8 +76,8 @@ def transaction_rpc_to_rlp_structure(dictionary: Dict[str, Any]) -> Dict[str, An
 
 
 def _access_list_rpc_to_rlp_structure(
-    access_list: Sequence[Dict[str, Any]]
-) -> Tuple[Tuple[str, Tuple[str]], ...]:
+    access_list: AccessList,
+) -> RLPStructuredAccessList:
     if not is_rpc_structured_access_list(access_list):
         raise ValueError(
             "provided object not formatted as JSON-RPC-structured access list"
@@ -108,8 +108,8 @@ def transaction_rlp_to_rpc_structure(dictionary: Dict[str, Any]) -> Dict[str, An
 
 
 def _access_list_rlp_to_rpc_structure(
-    access_list: Sequence[Any],
-) -> Sequence[Dict[str, Any]]:
+    access_list: RLPStructuredAccessList,
+) -> AccessList:
     if not is_rlp_structured_access_list(access_list):
         raise ValueError("provided object not formatted as rlp-structured access list")
 

--- a/eth_account/_utils/validation.py
+++ b/eth_account/_utils/validation.py
@@ -102,7 +102,8 @@ def is_rlp_structured_access_list(val: Any) -> bool:
     return True
 
 
-@curry
+# type ignored because curry doesn't preserve typing
+@curry  # type: ignore[misc]
 def is_sequence_of_bytes_or_hexstr(
     value: Any, item_bytes_size: Optional[int] = None, can_be_empty: bool = False
 ) -> bool:

--- a/eth_account/types.py
+++ b/eth_account/types.py
@@ -19,5 +19,6 @@ Bytes32 = bytes
 PrivateKeyType = Union[Bytes32, int, HexStr, PrivateKey]
 
 AccessList = Sequence[Dict[str, Union[HexStr, Sequence[HexStr]]]]
+RLPStructuredAccessList = Sequence[Sequence[Union[HexStr, Sequence[HexStr]]]]
 
 TransactionDictType = Dict[str, Union[AccessList, bytes, HexStr, int]]

--- a/newsfragments/285.internal.rst
+++ b/newsfragments/285.internal.rst
@@ -1,0 +1,1 @@
+Set mypy rules ``disallow_any_generics``, ``disallow_subclassing_any``, and ``disallow_untyped_decorators`` to ``true``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,11 @@ use_parentheses = true
 
 [tool.mypy]
 check_untyped_defs = true
-disallow_any_generics = false
+disallow_any_generics = true
 disallow_incomplete_defs = true
-disallow_subclassing_any = false
+disallow_subclassing_any = true
 disallow_untyped_calls = true
-disallow_untyped_decorators = false
+disallow_untyped_decorators = true
 disallow_untyped_defs = true
 ignore_missing_imports = true
 strict_equality = true


### PR DESCRIPTION
### What was wrong?

Tighten up typing!

Closes #101

### How was it fixed?

Set `mypy` rules `disallow_any_generics`, `disallow_subclassing_any` and `disallow_untyped_decorators` to `true`, fix errors

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-account/assets/5199899/12a93248-2429-4c22-b729-59ecb6dcc9e9)
