### PR TITLE
Typed dict for transaction dicts

### DIFF
--- a/eth_account/_utils/legacy_transactions.py
+++ b/eth_account/_utils/legacy_transactions.py
@@ -35,7 +35,7 @@ from eth_account.typed_transactions import (
 )
 from eth_account.types import (
     Blobs,
-    TransactionDictType,
+    TxParams,
 )
 
 from .transaction_utils import (
@@ -69,7 +69,7 @@ class UnsignedTransaction(HashableRLP):
 
 
 def serializable_unsigned_transaction_from_dict(
-    transaction_dict: TransactionDictType, blobs: Optional[Blobs] = None
+    transaction_dict: TxParams, blobs: Optional[Blobs] = None
 ) -> Union[TypedTransaction, Transaction, UnsignedTransaction]:
     transaction_dict = set_transaction_type_if_needed(transaction_dict)
     if "type" in transaction_dict:
@@ -142,7 +142,7 @@ REQUIRED_TRANSACTION_KEYS = ALLOWED_TRANSACTION_KEYS.difference(
 )
 
 
-def assert_valid_fields(transaction_dict: TransactionDictType) -> None:
+def assert_valid_fields(transaction_dict: TxParams) -> None:
     # check if any keys are missing
     missing_keys = REQUIRED_TRANSACTION_KEYS.difference(transaction_dict.keys())
     if missing_keys:
@@ -170,7 +170,7 @@ def assert_valid_fields(transaction_dict: TransactionDictType) -> None:
         raise TypeError(f"Transaction had invalid fields: {repr(invalid)}")
 
 
-def chain_id_to_v(transaction_dict: TransactionDictType) -> Dict[str, Any]:
+def chain_id_to_v(transaction_dict: TxParams) -> Dict[str, Any]:
     # See EIP 155
     chain_id = transaction_dict.pop("chainId")
     if chain_id is None:
@@ -182,9 +182,9 @@ def chain_id_to_v(transaction_dict: TransactionDictType) -> Dict[str, Any]:
 # type ignored because curry doesn't preserve typing
 @curry  # type: ignore[misc]
 def fill_transaction_defaults(
-    transaction_dict: TransactionDictType,
-) -> TransactionDictType:
-    return cast(TransactionDictType, merge(TRANSACTION_DEFAULTS, transaction_dict))
+    transaction_dict: TxParams,
+) -> TxParams:
+    return cast(TxParams, merge(TRANSACTION_DEFAULTS, transaction_dict))
 
 
 ChainAwareUnsignedTransaction = Transaction

--- a/eth_account/_utils/signing.py
+++ b/eth_account/_utils/signing.py
@@ -29,7 +29,7 @@ from eth_account.typed_transactions import (
 from eth_account.types import (
     Blobs,
     Bytes32,
-    TransactionDictType,
+    TxParams,
 )
 
 CHAIN_ID_OFFSET = 35
@@ -43,7 +43,7 @@ STRUCTURED_DATA_SIGN_VERSION = b"\x01"  # Hex value 0x01
 
 def sign_transaction_dict(
     eth_key: PrivateKey,
-    transaction_dict: TransactionDictType,
+    transaction_dict: TxParams,
     blobs: Optional[Blobs] = None,
 ) -> Tuple[int, int, int, bytes]:
     # generate RLP-serializable transaction, with defaults filled

--- a/eth_account/_utils/transaction_utils.py
+++ b/eth_account/_utils/transaction_utils.py
@@ -15,7 +15,7 @@ from eth_account._utils.validation import (
 from eth_account.types import (
     AccessList,
     RLPStructuredAccessList,
-    TransactionDictType,
+    TxParams,
 )
 
 
@@ -38,8 +38,8 @@ def normalize_transaction_dict(txn_dict: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def set_transaction_type_if_needed(
-    transaction_dict: TransactionDictType,
-) -> TransactionDictType:
+    transaction_dict: TxParams,
+) -> TxParams:
     if "type" not in transaction_dict:
         if all(
             type_1_arg in transaction_dict for type_1_arg in ("gasPrice", "accessList")

--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -96,7 +96,7 @@ from eth_account.typed_transactions import (
 from eth_account.types import (
     Blobs,
     PrivateKeyType,
-    TransactionDictType,
+    TxParams,
 )
 
 VRS = TypeVar("VRS", bytes, HexStr, int)
@@ -664,7 +664,7 @@ class Account(AccountLocalActions):
     @combomethod
     def sign_transaction(
         self,
-        transaction_dict: TransactionDictType,
+        transaction_dict: TxParams,
         private_key: PrivateKeyType,
         blobs: Optional[Blobs] = None,
     ) -> SignedTransaction:

--- a/eth_account/account_local_actions.py
+++ b/eth_account/account_local_actions.py
@@ -29,7 +29,7 @@ from eth_account.messages import (
 from eth_account.types import (
     Blobs,
     PrivateKeyType,
-    TransactionDictType,
+    TxParams,
 )
 
 
@@ -67,7 +67,7 @@ class AccountLocalActions(ABC):
     @abstractmethod
     def sign_transaction(
         self,
-        transaction_dict: TransactionDictType,
+        transaction_dict: TxParams,
         private_key: PrivateKeyType,
         blobs: Optional[Blobs] = None,
     ) -> SignedTransaction:

--- a/eth_account/signers/base.py
+++ b/eth_account/signers/base.py
@@ -19,7 +19,7 @@ from eth_account.messages import (
     SignableMessage,
 )
 from eth_account.types import (
-    TransactionDictType,
+    TxParams,
 )
 
 
@@ -74,9 +74,7 @@ class BaseAccount(ABC):
         """
 
     @abstractmethod
-    def sign_transaction(
-        self, transaction_dict: TransactionDictType
-    ) -> SignedTransaction:
+    def sign_transaction(self, transaction_dict: TxParams) -> SignedTransaction:
         """
         Sign a transaction dict.
 

--- a/eth_account/signers/local.py
+++ b/eth_account/signers/local.py
@@ -31,7 +31,7 @@ from eth_account.signers.base import (
 )
 from eth_account.types import (
     Blobs,
-    TransactionDictType,
+    TxParams,
 )
 
 
@@ -124,7 +124,7 @@ class LocalAccount(BaseAccount):
         )
 
     def sign_transaction(
-        self, transaction_dict: TransactionDictType, blobs: Optional[Blobs] = None
+        self, transaction_dict: TxParams, blobs: Optional[Blobs] = None
     ) -> SignedTransaction:
         return cast(
             SignedTransaction,

--- a/eth_account/types.py
+++ b/eth_account/types.py
@@ -1,6 +1,8 @@
 from typing import (
     Dict,
+    NewType,
     Sequence,
+    TypedDict,
     Union,
 )
 
@@ -8,6 +10,8 @@ from eth_keys.datatypes import (
     PrivateKey,
 )
 from eth_typing import (
+    Address,
+    ChecksumAddress,
     HexStr,
 )
 from hexbytes import (
@@ -21,4 +25,40 @@ PrivateKeyType = Union[Bytes32, int, HexStr, PrivateKey]
 AccessList = Sequence[Dict[str, Union[HexStr, Sequence[HexStr]]]]
 RLPStructuredAccessList = Sequence[Sequence[Union[HexStr, Sequence[HexStr]]]]
 
-TransactionDictType = Dict[str, Union[AccessList, bytes, HexStr, int]]
+# TxParams = Dict[str, Union[AccessList, bytes, HexStr, int]]
+
+
+class AccessListEntry(TypedDict):
+    address: HexStr
+    storageKeys: Sequence[HexStr]
+
+
+AccessList = NewType("AccessList", Sequence[AccessListEntry])
+
+Nonce = NewType("Nonce", int)
+Wei = NewType("Wei", int)
+
+TxParams = TypedDict(
+    "TxParams",
+    {
+        "accessList": AccessList,
+        "blobVersionedHashes": Sequence[Union[str, HexStr, bytes, HexBytes]],
+        "chainId": int,
+        "data": Union[bytes, HexStr],
+        # addr or ens
+        "from": Union[Address, ChecksumAddress, str],
+        "gas": int,
+        # legacy pricing
+        "gasPrice": Wei,
+        "maxFeePerBlobGas": Union[str, Wei],
+        # dynamic fee pricing
+        "maxFeePerGas": Union[str, Wei],
+        "maxPriorityFeePerGas": Union[str, Wei],
+        "nonce": Nonce,
+        # addr or ens
+        "to": Union[Address, ChecksumAddress, str],
+        "type": Union[int, HexStr],
+        "value": Wei,
+    },
+    total=False,
+)


### PR DESCRIPTION
### What was wrong?

Transaction Dicts could use better typing, especially to play better with web3.py

### How was it fixed?

This is a test PR (at least to start), copying the `TxParams` typed dict and any needed sub-types over from web3. If it makes sense, next step will be to pull those types into eth-typing to be shared across both eth-account and web3.

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-account/assets/5199899/281a8170-0a50-403f-ae8d-0d14a307be9f)
