### PR TITLE
allow accessList storageKeys to be bytes

### DIFF
--- a/eth_account/_utils/validation.py
+++ b/eth_account/_utils/validation.py
@@ -79,7 +79,7 @@ def is_rpc_structured_access_list(val: Any) -> bool:
         if not is_list_like(storage_keys):
             return False
         for storage_key in storage_keys:
-            if not is_int_or_prefixed_hexstr(storage_key):
+            if not is_int_or_prefixed_hexstr(storage_key) and not is_bytes(storage_key):
                 return False
     return True
 
@@ -97,7 +97,7 @@ def is_rlp_structured_access_list(val: Any) -> bool:
         if not is_address(address):
             return False
         for storage_key in storage_keys:
-            if not is_int_or_prefixed_hexstr(storage_key):
+            if not is_int_or_prefixed_hexstr(storage_key) and not is_bytes(storage_key):
                 return False
     return True
 

--- a/tests/core/test_typed_transactions.py
+++ b/tests/core/test_typed_transactions.py
@@ -180,6 +180,40 @@ TEST_CASES = [
         },
     },
     {
+        "expected_type": AccessListTransaction,
+        "expected_hash": "0x8d46e14b6259a070e0c4a7be7ed73bb18838cfb022b9c381e426cf7b3e22ec12",  # noqa: E501
+        "expected_raw_transaction": "0x01f8e782076c22843b9aca00830186a09409616c3d61b3331fc4109a9e41a8bdb7d9776609865af3107a400086616263646566f872f85994de0b295669a9fd93d5f28d9ec85e40f4cb697baef842a00000000000000000000000000000000000000000000000000000000000000003a00000000000000000000000000000000000000000000000000000000000000007d694bb9bc244d798123fde783fcc1c72d3bb8c189413c001a08289e85fa00f8f7f78a53cf147a87b2a7f0d27e64d7571f9d06a802e365c3430a017dc77eae36c88937db4a5179f57edc6119701652f3f1c6f194d1210d638a061",  # noqa: 501
+        "transaction": {
+            "gas": "0x186a0",
+            "gasPrice": "0x3b9aca00",
+            "data": "0x616263646566",
+            "nonce": "0x22",
+            "to": "0x09616C3d61b3331fc4109a9E41a8BDB7d9776609",
+            "value": "0x5af3107a4000",
+            "accessList": (  # test case from EIP-2930
+                {
+                    "address": "0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae",
+                    "storageKeys": (
+                        HexBytes(
+                            "0x0000000000000000000000000000000000000000000000000000000000000003"  # noqa: E501
+                        ),
+                        HexBytes(
+                            "0x0000000000000000000000000000000000000000000000000000000000000007"  # noqa: E501
+                        ),
+                    ),
+                },
+                {
+                    "address": "0xbb9bc244d798123fde783fcc1c72d3bb8c189413",
+                    "storageKeys": (),
+                },
+            ),
+            "chainId": "0x76c",
+            "v": "0x1",
+            "r": "0x8289e85fa00f8f7f78a53cf147a87b2a7f0d27e64d7571f9d06a802e365c3430",
+            "s": "0x17dc77eae36c88937db4a5179f57edc6119701652f3f1c6f194d1210d638a061",
+        },
+    },
+    {
         "expected_type": DynamicFeeTransaction,
         "expected_hash": "0xa1ea3121940930f7e7b54506d80717f14c5163807951624c36354202a8bffda6",  # noqa: E501
         "expected_raw_transaction": "0x02f8758205390284773594008477359400830186a09496216849c49358b10257cb55b28ea603c874b05e865af3107a4000825544c001a0c3000cd391f991169ebfd5d3b9e93c89d31a61c998a21b07a11dc6b9d66f8a8ea022cfe8424b2fbd78b16c9911da1be2349027b0a3c40adf4b6459222323773f74",  # noqa: 501
@@ -347,6 +381,7 @@ TEST_CASE_IDS = [
     "al-many-lists",
     "al-as-list-not-tuple",
     "al-no-explicit-type",
+    "al-hexbytes-in-storage-keys",
     "df-1",
     "df-2-int-values-and-access-list",
     "df-no-explicit-type",


### PR DESCRIPTION
### What was wrong?
`web3` generates `accessList`s with `storageKeys` of type `HexBytes`, but `eth-account` only allows them to be `int`s or 0x-prefixed strings.

Closes #286

### How was it fixed?

Set validation to allow them to be `bytes`. Might make more sense to stay stricter only allow `HexBytes`

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/293648cd-8c5e-4413-85be-8c058d353e4c)
