### PR TITLE
Pin ckzg

### DIFF
--- a/newsfragments/292.internal.rst
+++ b/newsfragments/292.internal.rst
@@ -1,0 +1,1 @@
+Pin ckzg to <2.0. Something in 2.0 is causing blob tests to fail

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "eth-utils>=2.0.0",
         "hexbytes>=1.2.0",
         "rlp>=1.0.0",
-        "ckzg>=0.4.3",
+        "ckzg>=0.4.3,<2",
         "pydantic>=2.0.0",
     ],
     python_requires=">=3.8, <4",


### PR DESCRIPTION
### What was wrong?

Core tests are failing because of a ckzg update. 


### How was it fixed?

Pinned ckzg to <2.0 for now, since that's when the fails started. 

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.boredpanda.com/blog/wp-content/uploads/2022/03/62419c08735ae_y57kbzi3tmw41__700.jpg)
