### PR TITLE
Raise lower pin for eth-keyfile to >=0.7.0

### DIFF
--- a/newsfragments/297.bugfix.rst
+++ b/newsfragments/297.bugfix.rst
@@ -1,0 +1,1 @@
+Raise lower pin on ``eth-keyfile`` to ``>=0.7.0`` where a bug was fixed in the default values for ``scrypt`` generated keyfiles.

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     install_requires=[
         "bitarray>=2.4.0",
         "eth-abi>=4.0.0-b.2",
-        "eth-keyfile>=0.6.0",
+        "eth-keyfile>=0.7.0",
         "eth-keys>=0.4.0",
         "eth-rlp>=2.1.0",
         "eth-utils>=2.0.0",


### PR DESCRIPTION
### What was wrong?

closes #297

### How was it fixed?

- Raise the lower pin on `eth-keyfile` to `>=0.7.0` to prevent using older versions where default values for `scrypt` were not correctly defined.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![optimized](https://github.com/user-attachments/assets/e328dee9-501a-44fb-adac-f6d28e092c88)
