### PR TITLE
pin eth-keyfile <0.9.0 due to incoming breaking typing changes

### DIFF
--- a/newsfragments/299.internal.rst
+++ b/newsfragments/299.internal.rst
@@ -1,0 +1,1 @@
+Pin ``eth-keyfile <0.9.0`` due to breaking changes to typing

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     install_requires=[
         "bitarray>=2.4.0",
         "eth-abi>=4.0.0-b.2",
-        "eth-keyfile>=0.7.0",
+        "eth-keyfile>=0.7.0, <0.9.0",
         "eth-keys>=0.4.0",
         "eth-rlp>=2.1.0",
         "eth-utils>=2.0.0",


### PR DESCRIPTION
### What was wrong?

The release of `eth-keyfile v0.9.0` will have breaking changes to typing.

Related to Issue # https://github.com/ethereum/eth-keyfile/pull/55

### How was it fixed?

Pin `eth-keyfile <0.9.0`.
Once `eth-account` and `eth-keyfile` have releases, make that the new bottom pin here.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/0317962c-f7b8-40c4-b5b1-f839a9795933)
