### PR TITLE
Don't trigger HDAccount DeprecationWarning if Language enum is passed in

### DIFF
--- a/docs/eth_account.hdaccount.rst
+++ b/docs/eth_account.hdaccount.rst
@@ -3,20 +3,11 @@ HD Account
 
 .. CAUTION:: These features are experimental and unaudited
 
-HD Deterministic module
--------------------------------------------
-
-.. automodule:: eth_account.hdaccount.deterministic
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 HD Mnemonic module
---------------------------------------
+------------------
 
 .. automodule:: eth_account.hdaccount.mnemonic
    :members:
-   :undoc-members:
    :show-inheritance:
 
 Module contents

--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -12,7 +12,6 @@ from typing import (
     Union,
     cast,
 )
-import warnings
 
 from eth_keyfile import (
     create_keyfile_json,
@@ -425,13 +424,6 @@ class Account(AccountLocalActions):
                 "default until its API stabilizes. To use these features, please "
                 "enable them by running `Account.enable_unaudited_hdwallet_features()` "
                 "and try again."
-            )
-        if isinstance(language, str):
-            warnings.warn(
-                "The language parameter should be a Language enum, not a string. "
-                "This will be enforced in a future version.",
-                DeprecationWarning,
-                stacklevel=2,
             )
         mnemonic = generate_mnemonic(num_words, language)
         return self.from_mnemonic(mnemonic, passphrase, account_path), mnemonic

--- a/eth_account/hdaccount/__init__.py
+++ b/eth_account/hdaccount/__init__.py
@@ -22,13 +22,6 @@ ETHEREUM_DEFAULT_PATH = "m/44'/60'/0'/0/0"
 
 
 def generate_mnemonic(num_words: int, lang: Union[Language, str]) -> str:
-    if isinstance(lang, str):
-        warnings.warn(
-            "The language parameter should be a Language enum, not a string. "
-            "This will be enforced in a future version.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
     return Mnemonic(lang).generate(num_words)
 
 

--- a/eth_account/hdaccount/mnemonic.py
+++ b/eth_account/hdaccount/mnemonic.py
@@ -135,7 +135,7 @@ class Mnemonic:
         return sorted(Path(f).stem for f in WORDLIST_DIR.rglob("*.txt"))
 
     @classmethod
-    def detect_language(cls, raw_mnemonic: str) -> str:
+    def detect_language(cls, raw_mnemonic: str) -> Language:
         # return type will be a Language enum value in a future version
         mnemonic = normalize_string(raw_mnemonic)
 
@@ -156,7 +156,7 @@ class Mnemonic:
         if len(matching_languages) == 2 and all(
             "chinese" in lang for lang in matching_languages
         ):
-            return Language.CHINESE_SIMPLIFIED.value
+            return Language.CHINESE_SIMPLIFIED
 
         # Because certain wordlists share some similar words, if we detect multiple
         # languages that the provided mnemonic word(s) could be valid in, we have
@@ -167,7 +167,7 @@ class Mnemonic:
             )
 
         (language,) = matching_languages
-        return Language(language).value
+        return Language(language)
 
     def generate(self, num_words: int = 12) -> str:
         if num_words not in VALID_WORD_COUNTS:

--- a/eth_account/hdaccount/mnemonic.py
+++ b/eth_account/hdaccount/mnemonic.py
@@ -132,11 +132,20 @@ class Mnemonic:
 
     @staticmethod
     def list_languages() -> List[str]:
+        """
+        Returns a list of languages available for the seed phrase
+        """
         return sorted(Path(f).stem for f in WORDLIST_DIR.rglob("*.txt"))
+
+    @staticmethod
+    def list_languages_enum() -> List[Language]:
+        """
+        Returns a list of Language objects available for the seed phrase
+        """
+        return sorted(Language(Path(f).stem) for f in WORDLIST_DIR.rglob("*.txt"))
 
     @classmethod
     def detect_language(cls, raw_mnemonic: str) -> Language:
-        # return type will be a Language enum value in a future version
         mnemonic = normalize_string(raw_mnemonic)
 
         words = set(mnemonic.split(" "))

--- a/eth_account/hdaccount/mnemonic.py
+++ b/eth_account/hdaccount/mnemonic.py
@@ -94,6 +94,11 @@ class Mnemonic:
         >>> print(available_languages)
         ['chinese_simplified', 'chinese_traditional', 'czech', 'english', 'french', 'italian', 'japanese', 'korean', 'spanish']
 
+        >>> # List available enumerated languages
+        >>> available_languages = Mnemonic.list_languages_enum()
+        >>> print(available_languages)
+        [<Language.CHINESE_SIMPLIFIED: 'chinese_simplified'>, <Language.CHINESE_TRADITIONAL: 'chinese_traditional'>, <Language.CZECH: 'czech'>, <Language.ENGLISH: 'english'>, <Language.FRENCH: 'french'>, <Language.ITALIAN: 'italian'>, <Language.JAPANESE: 'japanese'>, <Language.KOREAN: 'korean'>, <Language.SPANISH: 'spanish'>]
+
         >>> # Generate a new mnemonic phrase
         >>> mnemonic_phrase = en_mnemonic.generate()
         >>> print(mnemonic_phrase) # doctest: +SKIP
@@ -179,6 +184,9 @@ class Mnemonic:
         return Language(language)
 
     def generate(self, num_words: int = 12) -> str:
+        """
+        Generate a new mnemonic with the specified number of words.
+        """
         if num_words not in VALID_WORD_COUNTS:
             raise ValidationError(
                 f"Invalid choice for number of words: {num_words}, should be one of "
@@ -214,6 +222,11 @@ class Mnemonic:
         return phrase
 
     def is_mnemonic_valid(self, mnemonic: str) -> bool:
+        """
+        Checks if mnemonic is valid
+
+        :param str mnemonic: Mnemonic string
+        """
         words = normalize_string(mnemonic).split(" ")
         num_words = len(words)
 

--- a/eth_account/types.py
+++ b/eth_account/types.py
@@ -35,3 +35,8 @@ class Language(enum.Enum):
     JAPANESE = "japanese"
     KOREAN = "korean"
     SPANISH = "spanish"
+
+    def __lt__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value < other.value
+        return NotImplemented

--- a/eth_account/types.py
+++ b/eth_account/types.py
@@ -1,5 +1,6 @@
 import enum
 from typing import (
+    Any,
     Dict,
     Sequence,
     Union,
@@ -36,7 +37,7 @@ class Language(enum.Enum):
     KOREAN = "korean"
     SPANISH = "spanish"
 
-    def __lt__(self, other):
-        if self.__class__ is other.__class__:
+    def __lt__(self, other: Any) -> Any:
+        if other.__class__ is Language:
             return self.value < other.value
         return NotImplemented

--- a/newsfragments/302.feature.rst
+++ b/newsfragments/302.feature.rst
@@ -1,0 +1,1 @@
+Add new list_languages_enum method to HDAccount class

--- a/tests/core/test_hdaccount.py
+++ b/tests/core/test_hdaccount.py
@@ -98,7 +98,11 @@ def test_unknown_language():
     with pytest.raises(
         ValidationError, match="Invalid language choice 'pig_latin', must be one of.*"
     ):
-        Account.create_with_mnemonic(language="pig latin")
+        with pytest.warns(
+            DeprecationWarning,
+            match="The language parameter should be a Language enum, not a string*.",
+        ):
+            Account.create_with_mnemonic(language="pig latin")
 
 
 def test_known_language_as_string_warns():

--- a/tests/core/test_mnemonic.py
+++ b/tests/core/test_mnemonic.py
@@ -58,14 +58,18 @@ def test_failed_checksum():
     ],
 )
 def test_detection(language, word):
-    assert language.value == Mnemonic.detect_language(word)
+    assert language == Mnemonic.detect_language(word)
 
 
 def test_undetected_language():
     with pytest.raises(ValidationError):
         Mnemonic.detect_language("xxxxxxx")
     with pytest.raises(ValidationError):
-        Mnemonic("xxxxxxx")
+        with pytest.warns(
+            DeprecationWarning,
+            match="The language parameter should be a Language enum, not a string",
+        ):
+            Mnemonic("xxxxxxx")
 
 
 def test_expand_word():
@@ -116,10 +120,10 @@ def test_generation(lang, num_words):
     # NOTE: Sometimes traditional chinese can return characters that are also
     # valid simplified chinese characters. In that scenario, the detection
     # algorithm will assume simplified.
-    if lang == "chinese_traditional":
-        assert "chinese" in Mnemonic.detect_language(mnemonic)
+    if lang == Language("chinese_simplified"):
+        assert "chinese" in Mnemonic.detect_language(mnemonic).value
     else:
-        assert Mnemonic.detect_language(mnemonic) == lang.value
+        assert Mnemonic.detect_language(mnemonic) == lang
     assert len(Mnemonic.to_seed(mnemonic)) == 64
 
 

--- a/tests/core/test_mnemonic.py
+++ b/tests/core/test_mnemonic.py
@@ -110,10 +110,9 @@ def test_expand(lang):
             assert m.expand(norm_word[: size + 1]) == word
 
 
-@pytest.mark.parametrize("lang", Mnemonic.list_languages())
+@pytest.mark.parametrize("lang", Mnemonic.list_languages_enum())
 @pytest.mark.parametrize("num_words", [12, 15, 18, 21, 24])
-def test_generation(lang, num_words):
-    lang = Language(lang)
+def test_generation_with_enum(lang, num_words):
     m = Mnemonic(lang)
     mnemonic = m.generate(num_words)
     assert m.is_mnemonic_valid(mnemonic)
@@ -124,6 +123,23 @@ def test_generation(lang, num_words):
         assert "chinese" in Mnemonic.detect_language(mnemonic).value
     else:
         assert Mnemonic.detect_language(mnemonic) == lang
+    assert len(Mnemonic.to_seed(mnemonic)) == 64
+
+
+@pytest.mark.parametrize("lang", Mnemonic.list_languages())
+@pytest.mark.parametrize("num_words", [12, 15, 18, 21, 24])
+def test_generation_with_string(lang, num_words):
+    with pytest.warns(DeprecationWarning):
+        m = Mnemonic(lang)
+    mnemonic = m.generate(num_words)
+    assert m.is_mnemonic_valid(mnemonic)
+    # NOTE: Sometimes traditional chinese can return characters that are also
+    # valid simplified chinese characters. In that scenario, the detection
+    # algorithm will assume simplified.
+    if lang == "chinese_simplified":
+        assert "chinese" in Mnemonic.detect_language(mnemonic).value
+    else:
+        assert Mnemonic.detect_language(mnemonic) == Language(lang)
     assert len(Mnemonic.to_seed(mnemonic)) == 64
 
 


### PR DESCRIPTION
### What was wrong?
We made the language that gets passed into the HD Accounts an `Enum`, and deprecated passing the string representation in. However, the DeprecationWarning was getting raised even though an Enum got passed.


### How was it fixed?
Removed extraneous DeprecationWarnings, and changed the return value of `detect_language` because I didn't see it documented anywhere, and therefore I am assuming it was meant to be a private method. Also added a new `list_languages_enum` method. Could stand to come up with a better name for that method, if you have any ideas. Additionally, added a few tests.
### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md) - only added a feature newsfragment because the bugfix portion hadn't been released.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://preview.redd.it/this-cute-quokka-v0-6oppejma1tmb1.jpg?width=640&crop=smart&auto=webp&s=6b8165c12559d0a786cc23e67e315671a140e062)
