### PR TITLE
bump keyfile and abi versions, fix new lint errors

### DIFF
--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -200,7 +200,7 @@ class Account(AccountLocalActions):
         # type ignored because eth_keyfile appears to be using the wrong type for
         # the password arg.
         # once fixed there, this should error and can be removed
-        return HexBytes(decode_keyfile_json(keyfile, password_bytes))  # type: ignore[arg-type]  # noqa: E501
+        return HexBytes(decode_keyfile_json(keyfile, password_bytes))
 
     @classmethod
     def encrypt(
@@ -270,7 +270,7 @@ class Account(AccountLocalActions):
         # the password arg.
         # once fixed there, this should error and can be removed
         return create_keyfile_json(
-            key_bytes, password_bytes, kdf=kdf, iterations=iterations  # type: ignore[arg-type]  # noqa: E501
+            key_bytes, password_bytes, kdf=kdf, iterations=iterations
         )
 
     @combomethod

--- a/newsfragments/305.breaking.rst
+++ b/newsfragments/305.breaking.rst
@@ -1,0 +1,1 @@
+Move ``eth-keyfile`` dependency up to ``>=0.9.0`` to account for change in typing there.

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,8 @@ setup(
     include_package_data=True,
     install_requires=[
         "bitarray>=2.4.0",
-        "eth-abi>=4.0.0-b.2",
-        "eth-keyfile>=0.7.0, <0.9.0",
+        "eth-abi>=4.0.0",
+        "eth-keyfile>=0.9.0",
         "eth-keys>=0.4.0",
         "eth-rlp>=2.1.0",
         "eth-utils>=2.0.0",


### PR DESCRIPTION
### What was wrong?

`eth-keyfile v0.9.0` was released, so we can now bump its dep here to `>=0.9.0`.

### How was it fixed?

Bumped and fixed minor lint errors. Removed the beta from the `eth-abi` dep too.
Closes #305 

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/3796560a-41f9-4218-8ed6-a196315d05fe)
