### PR TITLE
use deepcopy for eip712 messages so they don't get mutated across tests

### DIFF
--- a/newsfragments/308.internal.rst
+++ b/newsfragments/308.internal.rst
@@ -1,0 +1,1 @@
+``deepcopy`` EIP712 messages used in test to avoid unintended mutation.

--- a/tests/core/test_encode_typed_data/test_encode_typed_data_full_messages.py
+++ b/tests/core/test_encode_typed_data/test_encode_typed_data_full_messages.py
@@ -1,4 +1,7 @@
 import pytest
+from copy import (
+    deepcopy,
+)
 import json
 
 from eth_utils import (
@@ -15,33 +18,35 @@ from tests.eip712_messages import (
     convert_to_3_arg,
 )
 
+all_valid = deepcopy(ALL_VALID_EIP712_MESSAGES)
+invalid = deepcopy(INVALID)
+one_arg_invalid = deepcopy(ONE_ARG_INVALID)
 
-@pytest.mark.parametrize(
-    "test_cases", (ALL_VALID_EIP712_MESSAGES, INVALID, ONE_ARG_INVALID)
-)
+
+@pytest.mark.parametrize("test_cases", (all_valid, invalid, one_arg_invalid))
 def test_there_are_no_duplicate_test_cases(test_cases):
     string_test_cases = [json.dumps(msg, sort_keys=True) for msg in test_cases.values()]
     assert len(string_test_cases) == len(set(string_test_cases))
 
 
-@pytest.mark.parametrize("message", ALL_VALID_EIP712_MESSAGES)
+@pytest.mark.parametrize("message", all_valid)
 def test_valid_messages(message):
-    assert encode_typed_data(
-        full_message=ALL_VALID_EIP712_MESSAGES[message]
-    ) == encode_typed_data(*convert_to_3_arg(ALL_VALID_EIP712_MESSAGES[message]))
+    assert encode_typed_data(full_message=all_valid[message]) == encode_typed_data(
+        *convert_to_3_arg(all_valid[message])
+    )
 
 
-@pytest.mark.parametrize("message", INVALID)
+@pytest.mark.parametrize("message", invalid)
 def test_invalid_messages(message):
     with pytest.raises(ValueError):
-        encode_typed_data(full_message=INVALID[message])
+        encode_typed_data(full_message=invalid[message])
 
     with pytest.raises(ValueError):
-        encode_typed_data(*convert_to_3_arg(INVALID[message]))
+        encode_typed_data(*convert_to_3_arg(invalid[message]))
 
 
-@pytest.mark.parametrize("message", ONE_ARG_INVALID)
+@pytest.mark.parametrize("message", one_arg_invalid)
 def test_messages_that_are_only_invalid_for_one_arg_encoding(message):
     with pytest.raises(ValidationError):
-        encode_typed_data(full_message=ONE_ARG_INVALID[message])
-    encode_typed_data(*convert_to_3_arg(ONE_ARG_INVALID[message]))
+        encode_typed_data(full_message=one_arg_invalid[message])
+    encode_typed_data(*convert_to_3_arg(one_arg_invalid[message]))

--- a/tests/integration/test_comparison_js_eip712_signing.py
+++ b/tests/integration/test_comparison_js_eip712_signing.py
@@ -1,4 +1,7 @@
 import pytest
+from copy import (
+    deepcopy,
+)
 import json
 import subprocess
 
@@ -14,6 +17,10 @@ from tests.eip712_messages import (
     VALID_FOR_PY_AND_METAMASK,
     convert_to_3_arg,
 )
+
+valid_for_all = deepcopy(VALID_FOR_ALL)
+valid_for_py_and_ethers = deepcopy(VALID_FOR_PY_AND_ETHERS)
+valid_for_py_and_metamask = deepcopy(VALID_FOR_PY_AND_METAMASK)
 
 TEST_KEY = "756e69636f726e73756e69636f726e73756e69636f726e73756e69636f726e73"
 py_account = Account.from_key(TEST_KEY)
@@ -34,9 +41,9 @@ def get_js_sig(message, library):
 
 
 @pytest.mark.compatibility
-@pytest.mark.parametrize("message_title", VALID_FOR_ALL)
+@pytest.mark.parametrize("message_title", valid_for_all)
 def test_messages_where_all_3_sigs_match(message_title):
-    message = VALID_FOR_ALL[message_title]
+    message = valid_for_all[message_title]
 
     ethers_sig = get_js_sig(message, "ethers")
     metamask_sig = get_js_sig(message, "metamask")
@@ -59,9 +66,9 @@ def test_messages_where_all_3_sigs_match(message_title):
 
 
 @pytest.mark.compatibility
-@pytest.mark.parametrize("message_title", VALID_FOR_PY_AND_ETHERS)
+@pytest.mark.parametrize("message_title", valid_for_py_and_ethers)
 def test_messages_where_eth_account_matches_ethers_but_not_metamask(message_title):
-    message = VALID_FOR_PY_AND_ETHERS[message_title]
+    message = valid_for_py_and_ethers[message_title]
 
     ethers_sig = get_js_sig(message, "ethers")
     metamask_sig = get_js_sig(message, "metamask")
@@ -85,9 +92,9 @@ def test_messages_where_eth_account_matches_ethers_but_not_metamask(message_titl
 
 
 @pytest.mark.compatibility
-@pytest.mark.parametrize("message_title", VALID_FOR_PY_AND_METAMASK)
+@pytest.mark.parametrize("message_title", valid_for_py_and_metamask)
 def test_messages_where_eth_account_matches_metamask_but_not_ethers(message_title):
-    message = VALID_FOR_PY_AND_METAMASK[message_title]
+    message = valid_for_py_and_metamask[message_title]
 
     ethers_sig = get_js_sig(message, "ethers")
     metamask_sig = get_js_sig(message, "metamask")


### PR DESCRIPTION
### What was wrong?

Running `pytest tests/core` and `pytest tests/integration` separately both passed, but just `pytest tests` caused some integration tests to fail.

Closes #308 

### How was it fixed?

The messages used in test were being altered by the `core` tests, so `integration` was getting incorrect input. In test files where the `convert_to_3arg` function is used, `deepcopy` the messages before running tests.

It doesn't seem appropriate to add testing for this, as the problem only occurs when all the tests are run serially which would add a lot of time to CI.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/287ba240-3245-4e2f-abe5-de3a6f0b4524)
