### PR TITLE
remove duplicate 'view the changelong' line in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Read the [documentation](https://eth-account.readthedocs.io/).
 
 View the [change log](https://eth-account.readthedocs.io/en/latest/release_notes.html).
 
-View the [change log](https://eth-account.readthedocs.io/en/latest/release_notes.html).
-
 ## Installation
 
 ```sh


### PR DESCRIPTION
### What was wrong?

The changelog link in README was duplicated.

### How was it fixed?

Deduplicated.

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/c61130ba-27ea-42a1-a37c-62ed32706a7d)
