### PR TITLE
consider strings False and false and 0 to be false in encode_typed_data

### DIFF
--- a/eth_account/_utils/encode_typed_data/encoding_and_hashing.py
+++ b/eth_account/_utils/encode_typed_data/encoding_and_hashing.py
@@ -87,7 +87,8 @@ def encode_field(
         return ("bytes32", keccak(encode(data_types, data_hashes)))
 
     elif type_ == "bool":
-        return (type_, bool(value))
+        falsy_values = {"False", "false", "0"}
+        return (type_, False) if not value or value in falsy_values else (type_, True)
 
     # all bytes types allow hexstr and str values
     elif type_.startswith("bytes"):

--- a/eth_account/messages.py
+++ b/eth_account/messages.py
@@ -255,6 +255,10 @@ def encode_typed_data(
         - ``int`` and ``uint`` types will also accept strings. If prefixed with ``"0x"``
           , the string will be interpreted as hex. Otherwise, it will be interpreted as
           decimal.
+        - Any value for a ``bool`` type that Python considers "falsy" will be
+          interpreted as ``False``. The strings ``"False"``, ``"false"``, and ``"0"``
+          will be also interpreted as ``False``. All other values will be interpreted as
+          ``True``.
 
     Noteable differences from ``signTypedData``:
         - Custom types that are not alphanumeric will encode differently.

--- a/newsfragments/303.bugfix.rst
+++ b/newsfragments/303.bugfix.rst
@@ -1,0 +1,1 @@
+Adds logic to interpret the string values ``"False"``, ``"false"``, and ``"0"`` as ``False`` when encoding EIP712 messages.

--- a/tests/core/test_encode_typed_data/test_encode_typed_data_internals.py
+++ b/tests/core/test_encode_typed_data/test_encode_typed_data_internals.py
@@ -327,7 +327,16 @@ def test_get_primary_type_fail(types, expected):
             "false",
             (
                 "bool",
-                True,
+                False,
+            ),
+        ),
+        (
+            "a_bool",
+            "bool",
+            "False",
+            (
+                "bool",
+                False,
             ),
         ),
         (
@@ -345,7 +354,7 @@ def test_get_primary_type_fail(types, expected):
             "0",
             (
                 "bool",
-                True,
+                False,
             ),
         ),
         (
@@ -494,9 +503,10 @@ def test_get_primary_type_fail(types, expected):
         "bytes value b'\x01' for bool type returns True",
         "bytes value b'\x00' for bool type returns True",
         "string 'true' value for bool type returns True",
-        "string 'false' value for bool type returns True",
+        "string 'false' value for bool type returns False",
+        "string 'False' value for bool type returns False",
         "string '1' value for bool type returns True",
-        "string '0' value for bool type returns True",
+        "string '0' value for bool type returns False",
         "address value for address type",
         "int16 value for int16 type",
         "uint256 value for uint256 type",


### PR DESCRIPTION
### What was wrong?

When dealing with EIP712 messages, depending on how they are converted, it is reasonable to assume that if a `bool` type has the string value "False", "false", or "0", it should be interpreted as `False`.

Closes #303 

### How was it fixed?

Added logic to interpret those strings as `False`.

~~This is considered breaking, so will need to wait for the next breaking round of releases to be merged.~~
We decided this should be considered a bugfix.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/599b330d-7457-42aa-a6df-1cc298762878)
