### PR TITLE
Inherit from eth-utils CamelModel for pydantic types:

### DIFF
--- a/eth_account/_utils/transaction_utils.py
+++ b/eth_account/_utils/transaction_utils.py
@@ -2,6 +2,9 @@ from typing import (
     Any,
 )
 
+from eth_utils import (
+    CamelModel,
+)
 from toolz import (
     assoc,
     dissoc,
@@ -12,9 +15,6 @@ from eth_account._utils.validation import (
     is_rlp_structured_authorization_list,
     is_rpc_structured_access_list,
     is_rpc_structured_authorization_list,
-)
-from eth_account.datastructures import (
-    CustomPydanticModel,
 )
 from eth_account.types import (
     AccessList,
@@ -82,7 +82,7 @@ def json_serialize_classes_in_transaction(val: Any) -> Any:
     - ``exclude=val._exclude:   Fields excluded for serialization are defined within a
                                 ``_exclude`` property on the pydantic model.
     """
-    if isinstance(val, CustomPydanticModel):
+    if isinstance(val, CamelModel):
         return val.model_dump(by_alias=True)
     elif isinstance(val, dict):
         return {k: json_serialize_classes_in_transaction(v) for k, v in val.items()}

--- a/eth_account/datastructures.py
+++ b/eth_account/datastructures.py
@@ -4,7 +4,6 @@ from typing import (
     SupportsIndex,
     overload,
 )
-import warnings
 
 from eth_keys.datatypes import (
     Signature,
@@ -13,29 +12,15 @@ from eth_typing import (
     ChecksumAddress,
 )
 from eth_utils import (
+    CamelModel,
     to_checksum_address,
 )
 from hexbytes import (
     HexBytes,
 )
 from pydantic import (
-    BaseModel,
-    ConfigDict,
     Field,
     field_serializer,
-)
-from pydantic.alias_generators import (
-    to_camel,
-)
-from pydantic.json_schema import (
-    DEFAULT_REF_TEMPLATE,
-    GenerateJsonSchema,
-    JsonSchemaMode,
-    JsonSchemaValue,
-)
-from pydantic_core import (
-    CoreSchema,
-    PydanticOmit,
 )
 
 
@@ -105,64 +90,7 @@ class SignedMessage(
             raise TypeError("Index must be an integer, slice, or string")
 
 
-class OmitJsonSchema(GenerateJsonSchema):
-    def handle_invalid_for_json_schema(
-        self, schema: CoreSchema, error_info: str
-    ) -> JsonSchemaValue:
-        raise PydanticOmit
-
-
-class CustomPydanticModel(BaseModel):
-    """
-    A base class for eth-account pydantic models that provides custom JSON-RPC
-    serialization configuration. JSON-RPC serialization is configured to use
-    camelCase keys and to exclude fields that are marked as ``exclude=True``. To
-    serialize a model to the expected JSON-RPC format, use
-    ``model_dump(by_alias=True)``.
-    """
-
-    model_config = ConfigDict(
-        arbitrary_types_allowed=True,
-        populate_by_name=True,  # populate by snake_case (python) args
-        alias_generator=to_camel,  # serialize by camelCase (json-rpc) keys
-    )
-
-    def recursive_model_dump(self) -> Any:
-        # TODO: Remove in next major release. This was introduced because of a bug with
-        #  a ``@field_serializer`` decorator not being applied correctly to nested
-        #  models. This is no longer necessary.
-        warnings.warn(
-            "recursive_model_dump() is deprecated. Please use "
-            "model_dump(by_alias=True) instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.model_dump(by_alias=True)
-
-    @classmethod
-    def model_json_schema(
-        cls,
-        by_alias: bool = True,
-        ref_template: str = DEFAULT_REF_TEMPLATE,
-        # default to ``OmitJsonSchema`` to prevent errors from excluded fields
-        schema_generator: type[GenerateJsonSchema] = OmitJsonSchema,
-        mode: JsonSchemaMode = "validation",
-        **kwargs: Any,
-    ) -> dict[str, Any]:
-        """
-        Omits excluded fields from the JSON schema, preventing errors that would
-        otherwise be raised by the default schema generator.
-        """
-        return super().model_json_schema(
-            by_alias=by_alias,
-            ref_template=ref_template,
-            schema_generator=schema_generator,
-            mode=mode,
-            **kwargs,
-        )
-
-
-class SignedSetCodeAuthorization(CustomPydanticModel):
+class SignedSetCodeAuthorization(CamelModel):
     chain_id: int
     address: bytes
     nonce: int

--- a/tests/core/_test_utils.py
+++ b/tests/core/_test_utils.py
@@ -1,6 +1,9 @@
 from eth_keys.datatypes import (
     Signature,
 )
+from eth_utils import (
+    CamelModel,
+)
 from hexbytes import (
     HexBytes,
 )
@@ -9,7 +12,6 @@ from pydantic import (
 )
 
 from eth_account.datastructures import (
-    CustomPydanticModel,
     SignedSetCodeAuthorization,
 )
 
@@ -41,7 +43,7 @@ PYDANTIC_TEST_CLASS_JSON = {
 }
 
 
-class PydanticTestClassInner(CustomPydanticModel):
+class PydanticTestClassInner(CamelModel):
     int_value: int = 2
     str_value: str = "3"
     authorization_list: list[SignedSetCodeAuthorization] = [TEST_SIGNED_AUTHORIZATION]
@@ -49,7 +51,7 @@ class PydanticTestClassInner(CustomPydanticModel):
     excluded_field2: int = Field(default=5, exclude=True)
 
 
-class PydanticTestClass(CustomPydanticModel):
+class PydanticTestClass(CamelModel):
     int_value: int = 1
     nested_model: PydanticTestClassInner = PydanticTestClassInner()
     excluded_field1: str = Field(default="6", exclude=True)

--- a/tests/core/test_datastructures.py
+++ b/tests/core/test_datastructures.py
@@ -1,5 +1,4 @@
 import pytest
-import json
 
 from pydantic.alias_generators import (
     to_camel,
@@ -22,14 +21,11 @@ from tests.core._test_utils import (
 )
 def test_pydantic_model_serialization(pydantic_model, expected):
     json_model_dump = pydantic_model.model_dump(by_alias=True)
-    with pytest.warns(DeprecationWarning):
-        recursive_dump = pydantic_model.recursive_model_dump()
-    assert json_model_dump == recursive_dump == expected
-    assert json.loads(json.dumps(recursive_dump)) == expected
+    assert json_model_dump == expected
 
     model_dump = pydantic_model.model_dump()
     snake_case_dump = pydantic_model.model_dump(by_alias=False)
-    assert snake_case_dump == model_dump != expected
+    assert snake_case_dump == model_dump
 
     camel_keys = {to_camel(key) for key in model_dump.keys()}
     assert set(camel_keys).issubset(set(expected.keys()))

--- a/tests/core/test_mnemonic.py
+++ b/tests/core/test_mnemonic.py
@@ -89,7 +89,7 @@ def test_expand_word():
 
 @pytest.mark.parametrize(
     "lang",
-    {
+    [
         Language(lang)
         for lang in Mnemonic.list_languages()
         if lang
@@ -100,7 +100,7 @@ def test_expand_word():
             "chinese_simplified",
             "chinese_traditional",
         )
-    },
+    ],
 )
 def test_expand(lang):
     m = Mnemonic(lang)

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ max_issue_threshold=1
 
 [testenv]
 commands=
-    core: coverage run -m pytest {posargs:tests/core}
+    core: coverage run -m pytest -n auto --maxprocesses=4 {posargs:tests/core}
     core: coverage report
     integration: pytest {posargs:tests/integration}
     docs: make check-docs-ci


### PR DESCRIPTION
### What was wrong?

- The ``CustomPydanticModel`` used here inspired a more general class to be used across our libraries. That change was recently introduced in ``eth-utils``, so inherit from that class here for now, with a note to use ``CamelModel`` directly for the next major version.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="474" alt="Screenshot 2025-04-14 at 16 15 17" src="https://github.com/user-attachments/assets/5390e0db-3a86-4ed0-8fe1-13eb555da09b" />
