### PR TITLE
Remove unwanted autogenerated docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ validate-newsfragments:
 check-docs: build-docs validate-newsfragments
 
 build-docs:
-	sphinx-apidoc -o docs/ . setup.py "*conftest*"
+	sphinx-apidoc -o docs/ . setup.py "*conftest*" tests
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	$(MAKE) -C docs doctest

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "eth-account"
-copyright = "2018-2023, The Ethereum Foundation"
+copyright = "2018-2025, The Ethereum Foundation"
 
 __version__ = setup_version
 # The version info for the project you're documenting, acts as replacement for
@@ -82,6 +82,7 @@ exclude_patterns = [
     "modules.rst",
     "eth_account.internal.rst",
     "eth_account.typed_transactions.blob_transactions.rst",
+    "tests",
 ]
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/newsfragments/321.bugfix.rst
+++ b/newsfragments/321.bugfix.rst
@@ -1,0 +1,1 @@
+Remove doc warnings and unwanted generated docs


### PR DESCRIPTION
### What was wrong?
A new tests/__init__ file made the tests dir a module which made sphinx want to pick it up for autodocs. Files were being generated, and warnings were being issued when running make docs. 


### How was it fixed?
Added `tests` to the exclude pattern for sphinx, and added `tests` to the excludes for sphinx-apidoc as well. 

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.shutterstock.com/image-photo/miniature-shetland-breed-pony-running-260nw-2248473797.jpg)
