### PR TITLE
Bump eth-utils to allow for CamelModel usage

### DIFF
--- a/newsfragments/329.breaking.rst
+++ b/newsfragments/329.breaking.rst
@@ -1,0 +1,1 @@
+Bump eth-utils requirement to >=5.3.0 to allow for CamelModel usage

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "eth-keyfile>=0.7.0, <0.9.0",
         "eth-keys>=0.4.0",
         "eth-rlp>=2.1.0",
-        "eth-utils>=2.0.0",
+        "eth-utils>=5.3.0",
         "hexbytes>=1.2.0",
         "rlp>=1.0.0",
         "ckzg>=2.0.0",


### PR DESCRIPTION
### What was wrong?
Title says it all. CamelModel is a nice utility class introduced in eth-utils 5.3.0, but we couldn't pull it in outside of the breaking change cycle. 

### How was it fixed?
Bumped the eth-utils dependency so that we can use CamelModel now.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://p16-common-sign.tiktokcdn-us.com/tos-useast8-p-0068-tx2/ogKAiiAiCEA4BIAA9lCMsTIMKsikBfKBKcU00h~tplv-tiktokx-origin.image?dr=9636&x-expires=1766210400&x-signature=PkojkJP4tR8YNngGFBFSNbvGv9s%3D&t=4d5b0474&ps=13740610&shp=81f88b70&shcp=55bbe6a9&idc=useast8)
