### PR TITLE
Improve private key parsing error messages

### DIFF
--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -1,3 +1,4 @@
+import binascii
 from collections.abc import (
     Mapping,
 )
@@ -885,11 +886,25 @@ class Account(AccountLocalActions):
         if isinstance(key, self._keys.PrivateKey):
             return key
 
-        hb_key = HexBytes(key)
+        try:
+            hb_key = HexBytes(key)
+        except binascii.Error as original_exception:
+            if isinstance(key, str):
+                raise ValueError(
+                    "The private key must be a valid hex string representing "
+                    "exactly 32 bytes."
+                ) from original_exception
+            raise
 
         try:
             return self._keys.PrivateKey(hb_key)
         except ValidationError as original_exception:
+            if isinstance(key, str):
+                raise ValueError(
+                    "The private key must be a hex string representing exactly "
+                    f"32 bytes, but the provided hex string represents {len(hb_key)} "
+                    "bytes."
+                ) from original_exception
             raise ValueError(
                 "The private key must be exactly 32 bytes long, instead of "
                 f"{len(hb_key)} bytes."

--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -290,6 +290,8 @@ class Account(AccountLocalActions):
         :type private_key: hex str, bytes, int or :class:`eth_keys.datatypes.PrivateKey`
         :return: object with methods for signing and encrypting
         :rtype: LocalAccount
+        :raises ValueError: If the private key is not valid hex or does not
+            represent exactly 32 bytes.
 
         .. doctest:: python
 

--- a/newsfragments/246.bugfix.rst
+++ b/newsfragments/246.bugfix.rst
@@ -1,0 +1,2 @@
+Improved ``Account.from_key()`` error messages for invalid hex private keys and
+hex strings that do not represent exactly 32 bytes.

--- a/tests/core/test_accounts.py
+++ b/tests/core/test_accounts.py
@@ -1,5 +1,6 @@
 import pytest
 import os
+import re
 
 from eth_keyfile.keyfile import (
     get_default_work_factor_for_kdf,
@@ -270,6 +271,30 @@ def test_eth_account_from_key_seed_restrictions(acct):
         acct.from_key(b"\xff" * 31)
     with pytest.raises(ValueError):
         acct.from_key(b"\xff" * 33)
+
+
+@pytest.mark.parametrize(
+    "private_key,expected_message",
+    (
+        (
+            "0x1234567812345678123456781234567812345678",
+            "The private key must be a hex string representing exactly 32 bytes, "
+            "but the provided hex string represents 20 bytes.",
+        ),
+        (
+            "0xxyz",
+            "The private key must be a valid hex string representing exactly "
+            "32 bytes.",
+        ),
+        (
+            b"\xff" * 31,
+            "The private key must be exactly 32 bytes long, instead of 31 bytes.",
+        ),
+    ),
+)
+def test_eth_account_from_key_error_messages(acct, private_key, expected_message):
+    with pytest.raises(ValueError, match=re.escape(expected_message)):
+        acct.from_key(private_key)
 
 
 def test_eth_account_from_key_properties(acct, PRIVATE_KEY):


### PR DESCRIPTION
### What was wrong?

Related to Issue #246
Closes #246

`Account.from_key()` still had one confusing private-key validation path. Hex strings with the wrong byte length already produced a clearer byte-count message on `main`, but invalid hex strings still surfaced the raw `binascii.Error`, and the wrong-length string path did not explicitly say that the string representation was the problem.

### How was it fixed?

- split the `HexBytes()` conversion and `PrivateKey()` validation paths inside `_parse_private_key()`
- convert invalid hex-string input into a clear `ValueError`
- keep the raw-byte length error for bytes-like inputs
- make the wrong-length string error explicitly say how many bytes the provided hex string represents
- add regression coverage for invalid hex strings, wrong-length hex strings, and wrong-length byte inputs
- add a small `from_key()` docstring note and a release-note fragment for the user-facing change

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-account/blob/main/newsfragments/README.md)

#### Verification

- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest tests/core/test_accounts.py -k 'from_key'`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest tests/core/test_accounts.py -k 'from_key_error_messages or from_key_seed_restrictions'`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/pre-commit run --files eth_account/account.py tests/core/test_accounts.py newsfragments/246.bugfix.rst`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python newsfragments/validate_files.py`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/towncrier build --draft --version preview`
