### PR TITLE
Preserve configured key backends during signing

### DIFF
--- a/eth_account/account.py
+++ b/eth_account/account.py
@@ -888,7 +888,7 @@ class Account(AccountLocalActions):
         hb_key = HexBytes(key)
 
         try:
-            return self._keys.PrivateKey(hb_key)
+            return self._keys.PrivateKey(hb_key, self._keys.backend)
         except ValidationError as original_exception:
             raise ValueError(
                 "The private key must be exactly 32 bytes long, instead of "

--- a/eth_account/signers/local.py
+++ b/eth_account/signers/local.py
@@ -162,5 +162,7 @@ class LocalAccount(BaseAccount):
     def sign_authorization(self, authorization: dict[str, Any]) -> SignedMessage:
         return cast(
             SignedMessage,
-            self._publicapi.sign_authorization(authorization, private_key=self._key_obj),
+            self._publicapi.sign_authorization(
+                authorization, private_key=self._key_obj
+            ),
         )

--- a/eth_account/signers/local.py
+++ b/eth_account/signers/local.py
@@ -107,7 +107,7 @@ class LocalAccount(BaseAccount):
             SignedMessage,
             self._publicapi.unsafe_sign_hash(
                 message_hash,
-                private_key=self.key,
+                private_key=self._key_obj,
             ),
         )
 
@@ -121,7 +121,7 @@ class LocalAccount(BaseAccount):
         """
         return cast(
             SignedMessage,
-            self._publicapi.sign_message(signable_message, private_key=self.key),
+            self._publicapi.sign_message(signable_message, private_key=self._key_obj),
         )
 
     def sign_transaction(
@@ -129,7 +129,9 @@ class LocalAccount(BaseAccount):
     ) -> SignedTransaction:
         return cast(
             SignedTransaction,
-            self._publicapi.sign_transaction(transaction_dict, self.key, blobs=blobs),
+            self._publicapi.sign_transaction(
+                transaction_dict, self._key_obj, blobs=blobs
+            ),
         )
 
     def sign_typed_data(
@@ -149,7 +151,7 @@ class LocalAccount(BaseAccount):
         return cast(
             SignedMessage,
             self._publicapi.sign_typed_data(
-                private_key=self.key,
+                private_key=self._key_obj,
                 domain_data=domain_data,
                 message_types=message_types,
                 message_data=message_data,
@@ -160,5 +162,5 @@ class LocalAccount(BaseAccount):
     def sign_authorization(self, authorization: dict[str, Any]) -> SignedMessage:
         return cast(
             SignedMessage,
-            self._publicapi.sign_authorization(authorization, private_key=self.key),
+            self._publicapi.sign_authorization(authorization, private_key=self._key_obj),
         )

--- a/newsfragments/322.bugfix.rst
+++ b/newsfragments/322.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed ``Account.set_key_backend()`` so raw-key signing and ``LocalAccount``
+signing both preserve the configured ``eth-keys`` backend.

--- a/tests/core/test_accounts.py
+++ b/tests/core/test_accounts.py
@@ -7,6 +7,9 @@ from eth_keyfile.keyfile import (
 from eth_keys import (
     keys,
 )
+from eth_keys.backends import (
+    NativeECCBackend,
+)
 from eth_utils import (
     is_checksum_address,
     to_bytes,
@@ -168,6 +171,18 @@ PRIVATE_KEY_AS_INT_ALT = (
 )
 PRIVATE_KEY_AS_OBJ_ALT = keys.PrivateKey(PRIVATE_KEY_AS_BYTES_ALT)
 ACCT_ADDRESS_ALT = "0xafd7f0E16A1814B854b45f551AFD493BE5F039F9"
+
+
+class TrackingBackend(NativeECCBackend):
+    sign_calls = 0
+
+    def ecdsa_sign(self, msg_hash, private_key):
+        type(self).sign_calls += 1
+        return super().ecdsa_sign(msg_hash, private_key)
+
+    @classmethod
+    def reset(cls):
+        cls.sign_calls = 0
 
 
 @pytest.fixture(
@@ -697,6 +712,29 @@ def test_eth_account_sign_transaction_from_eth_test(acct, transaction):
     # confirm that signed transaction can be recovered to the sender
     expected_sender = acct.from_key(key).address
     assert acct.recover_transaction(signed.raw_transaction) == expected_sender
+
+
+def test_set_key_backend_applies_to_sign_transaction_with_raw_private_key():
+    TrackingBackend.reset()
+    account_api = Account()
+    account_api.set_key_backend(TrackingBackend())
+    transaction = dissoc(ETH_TEST_TRANSACTIONS[0], "key", "signed", "unsigned")
+
+    account_api.sign_transaction(transaction, PRIVATE_KEY_AS_BYTES)
+
+    assert TrackingBackend.sign_calls == 1
+
+
+def test_local_account_sign_transaction_preserves_private_key_backend():
+    TrackingBackend.reset()
+    account = Account().from_key(
+        keys.PrivateKey(PRIVATE_KEY_AS_BYTES, TrackingBackend())
+    )
+    transaction = dissoc(ETH_TEST_TRANSACTIONS[0], "key", "signed", "unsigned")
+
+    account.sign_transaction(transaction)
+
+    assert TrackingBackend.sign_calls == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What changed
This preserves the configured eth-keys backend when signing with raw private keys and when signing through LocalAccount.

## Why
`Account.set_key_backend()` currently does not affect signing when the signing path reparses raw key bytes with the default backend. This means instance-configured backends are ignored in `Account.sign_transaction()` and `LocalAccount` signing paths.

## How
1. Pass the configured backend into `_parse_private_key()` when constructing `PrivateKey` objects from raw key material.
2. Reuse `LocalAccount._key_obj` for signing calls instead of passing raw bytes back through the public API.
3. Add regression tests covering both the raw-key transaction path and the `LocalAccount` path.
4. Add a bugfix newsfragment for issue `#322`.

Fixes #322

## Tests
1. `python -m pytest tests/core/test_accounts.py -k "set_key_backend or preserves_private_key_backend or sign_transaction"`
2. `python -m pytest tests/core/test_accounts.py -k "sign_message or unsafe_sign_hash or sign_typed_data"`
